### PR TITLE
Add a bytecode evaluator

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,5 +2,5 @@
 
 status=0
 python3.7 -m unittest discover || status=1
-python3.7 -m doctest -v *.py || status=1
+python3.7 -m doctest *.py || status=1
 exit $status

--- a/scheme.py
+++ b/scheme.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass
 from typing import (TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple,
                     Union, cast)
@@ -27,8 +28,13 @@ class SExp:
         self._environment = env
 
 
+class Value(SExp):
+    """An s-expression that's a valid run-time object."""
+    ...
+
+
 @dataclass(order=True)
-class SNum(SExp):
+class SNum(Value):
     """A lisp number"""
     value: int
 
@@ -40,7 +46,7 @@ class SNum(SExp):
 
 
 @dataclass
-class SSym(SExp):
+class SSym(Value):
     """A lisp symbol"""
     name: str
 
@@ -52,7 +58,7 @@ class SSym(SExp):
 
 
 @dataclass
-class SVect(SExp):
+class SVect(Value):
     """An n element vector
 
     >>> vect = SVect([

--- a/scheme.py
+++ b/scheme.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import (
-    List, Optional, Tuple, Iterable, Iterator,
-    Sequence, Union, cast, TYPE_CHECKING)
+from typing import (TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple,
+                    Union, cast)
+
+import bytecode
 
 if TYPE_CHECKING:
     from environment import Environment
@@ -164,12 +165,26 @@ def to_slist(x: Sequence[SExp]) -> SList:
     return acc
 
 
+def make_bool(x: bool) -> SSym:
+    """
+    Returns a scheme boolean.
+
+    >>> make_bool(True)
+    SSym(name='true')
+    >>> make_bool(False)
+    SSym(name='false')
+    """
+    if x:
+        return SSym('true')
+    return SSym('false')
+
+
 @dataclass
 class SFunction(SExp):
     name: SSym
     formals: SList
     body: SList
-
+    code: Optional[bytecode.Function] = None
     is_lambda: bool = False
 
 

--- a/test_bytecode.py
+++ b/test_bytecode.py
@@ -1,8 +1,9 @@
 import unittest
+from typing import Any
 
 import bytecode
-from bytecode import Var, SymLit
-from scheme import SSym
+from bytecode import Binop, NumLit, SymLit, Var
+from scheme import SNum, SSym, SVect
 
 
 class BytecodeTestCast(unittest.TestCase):
@@ -66,7 +67,7 @@ class BytecodeTestCast(unittest.TestCase):
         bb4.add_inst(bytecode.CopyInst(result, SymLit(SSym("false"))))
         bb4.terminator = bytecode.Jmp(end)
 
-        print(is_list)
+        assert is_list
 
     def test_example_tail_call(self) -> None:
         """
@@ -125,4 +126,95 @@ class BytecodeTestCast(unittest.TestCase):
         bb4.terminator = bytecode.Jmp(end)
 
         # These tests are just to test the API
-        print(is_list)
+        assert is_list
+
+    def test_example_inlined(self) -> None:
+        """
+        function list? (v0) entry=bb0
+        bb0:
+            v1 = typeof v0
+            v2 = sym_eq v1 'vector
+            br v2 bb1 false
+
+        bb1:
+            v3 = length v0
+            v4 = num_eq v3 0
+            br v4 true bb2
+
+        bb2:
+            v5 = num_eq v3 2
+            br v5 bb3 false
+
+        bb3:
+            v0 = load v0 [1]
+            jmp bb0
+
+        true:
+            result = 'true
+            jmp end
+
+        false:
+            result = 'false
+            jmp end
+
+        end:
+            return result
+
+        """
+        result = Var("result")
+        bb0 = bytecode.BasicBlock("bb0")
+        bb1 = bytecode.BasicBlock("bb1")
+        bb2 = bytecode.BasicBlock("bb2")
+        bb3 = bytecode.BasicBlock("bb3")
+        true = bytecode.BasicBlock("true")
+        false = bytecode.BasicBlock("false")
+        end = bytecode.ReturnBlock("end", result)
+        is_list = bytecode.Function(params=[Var("v0")], start=bb0, finish=end)
+
+        # These tests are just to test the API
+        bb0.add_inst(bytecode.TypeofInst(Var("v1"), Var("v0")))
+        bb0.add_inst(bytecode.BinopInst(
+            Var("v2"), Binop.SYM_EQ, Var("v1"), SymLit(SSym("vector"))))
+        bb0.terminator = bytecode.Br(Var("v2"), bb1, false)
+
+        bb1.add_inst(bytecode.LengthInst(Var("v3"), Var("v0")))
+        bb1.add_inst(bytecode.BinopInst(
+            Var("v4"), Binop.NUM_EQ, Var("v3"), NumLit(SNum(0))))
+        bb1.terminator = bytecode.Br(Var("v4"), true, bb2)
+
+        bb2.add_inst(bytecode.BinopInst(
+            Var("v5"), Binop.NUM_EQ, Var("v3"), NumLit(SNum(2))))
+        bb2.terminator = bytecode.Br(Var("v5"), bb3, false)
+
+        bb3.add_inst(bytecode.LoadInst(Var("v0"), Var("v0"), NumLit(SNum(1))))
+        bb3.terminator = bytecode.Jmp(bb0)
+
+        true.add_inst(bytecode.CopyInst(result, SymLit(SSym('true'))))
+        true.terminator = bytecode.Jmp(end)
+
+        false.add_inst(bytecode.CopyInst(result, SymLit(SSym('false'))))
+        false.terminator = bytecode.Jmp(end)
+
+        class Generator:
+            def __init__(self, gen: Any):
+                self.gen = gen
+                self.value = None
+
+            def __iter__(self) -> Any:
+                self.value = yield from self.gen
+
+            def run(self) -> None:
+                for _ in self:
+                    pass
+
+        env = bytecode.EvalEnv(local_env={Var("v0"): SNum(42)})
+        gen = Generator(is_list.run(env))
+        gen.run()
+        self.assertEqual(gen.value, SSym('false'))
+
+        env = bytecode.EvalEnv(local_env={
+            Var("v0"): SVect([SNum(42), SVect([SNum(69), SVect([])])])
+        })
+        gen = Generator(is_list.run(env))
+        gen.run()
+        self.assertEqual(gen.value, SSym('true'))


### PR DESCRIPTION
Some design notes:
- All `run` methods modify the input environment for their effect
- Larger `run` methods like for basic blocks or functions are generators that yield copies of the state after every instruction is run.

Fixes #2 