### PR TITLE
PTR_EQ fixes and improvements

### DIFF
--- a/bytecode.py
+++ b/bytecode.py
@@ -143,10 +143,7 @@ class BinopInst(Inst):
             assert isinstance(lhs, SSym) and isinstance(rhs, SSym)
             env[self.dest] = scheme.make_bool(lhs == rhs)
         elif self.op == Binop.PTR_EQ:
-            lhs_ok = isinstance(lhs, SVect) or isinstance(lhs, SFunction)
-            rhs_ok = isinstance(rhs, SVect) or isinstance(rhs, SFunction)
-            assert lhs_ok and rhs_ok
-            env[self.dest] = scheme.make_bool(lhs is rhs)
+            env[self.dest] = scheme.make_bool(lhs.address() == rhs.address())
         else:
             assert isinstance(lhs, SNum) and isinstance(rhs, SNum)
             if self.op == Binop.ADD:

--- a/bytecode.py
+++ b/bytecode.py
@@ -143,7 +143,9 @@ class BinopInst(Inst):
             assert isinstance(lhs, SSym) and isinstance(rhs, SSym)
             env[self.dest] = scheme.make_bool(lhs == rhs)
         elif self.op == Binop.PTR_EQ:
-            assert isinstance(lhs, SVect) and isinstance(rhs, SVect)
+            lhs_ok = isinstance(lhs, SVect) or isinstance(lhs, SFunction)
+            rhs_ok = isinstance(rhs, SVect) or isinstance(rhs, SFunction)
+            assert lhs_ok and rhs_ok
             env[self.dest] = scheme.make_bool(lhs is rhs)
         else:
             assert isinstance(lhs, SNum) and isinstance(rhs, SNum)

--- a/scheme.py
+++ b/scheme.py
@@ -34,6 +34,10 @@ class Value(SExp):
     def type_name(self) -> SSym:
         ...
 
+    @abstractmethod
+    def address(self) -> int:
+        ...
+
 
 @dataclass(order=True)
 class SNum(Value):
@@ -49,6 +53,9 @@ class SNum(Value):
     def type_name(self) -> SSym:
         return SSym('number')
 
+    def address(self) -> int:
+        return self.value
+
 
 @dataclass
 class SSym(Value):
@@ -63,6 +70,9 @@ class SSym(Value):
 
     def type_name(self) -> SSym:
         return SSym('symbol')
+
+    def address(self) -> int:
+        raise Exception("Should not take the address of a symbol")
 
 
 @dataclass
@@ -86,6 +96,9 @@ class SVect(Value):
 
     def type_name(self) -> SSym:
         return SSym('vector')
+
+    def address(self) -> int:
+        return id(self.items)
 
 
 @dataclass
@@ -206,6 +219,9 @@ class SFunction(Value):
 
     def type_name(self) -> SSym:
         return SSym('function')
+
+    def address(self) -> int:
+        return id(self.code)
 
 
 @dataclass


### PR DESCRIPTION
Now you can compare functions, vectors, and numbers as pointers.
Numbers act as pointer literals, functions are compared by the address of their code object, and vectors are compared as the address of their items field.
Taking the address of a symbol is illegal in this patch, since I think it would represent a miscompilation.