### PR TITLE
Execution stats

### DIFF
--- a/bytecode.py
+++ b/bytecode.py
@@ -532,9 +532,10 @@ class Function:
         while blocks:
             block = blocks.pop()
             yield block
-            blocks.extend(b for b in block.successors()
-                          if id(b) not in visited)
-            visited |= set(map(id, blocks))
+            for b in block.successors():
+                if id(b) not in visited:
+                    visited.add(id(b))
+                    blocks.append(b)
 
     def __str__(self) -> str:
         return (f"function (? {' '.join(x.name for x in self.params)})"

--- a/bytecode.py
+++ b/bytecode.py
@@ -162,7 +162,6 @@ class BinopInst(Inst):
     rhs: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         lhs = env[self.lhs]
         rhs = env[self.rhs]
         if self.op == Binop.SYM_EQ:
@@ -201,7 +200,6 @@ class TypeofInst(Inst):
     value: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         env[self.dest] = env[self.value].type_name()
 
     def __str__(self) -> str:
@@ -214,7 +212,6 @@ class CopyInst(Inst):
     value: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         env[self.dest] = env[self.value]
 
     def __str__(self) -> str:
@@ -227,7 +224,6 @@ class LookupInst(Inst):
     name: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         sym = env[self.name]
         assert isinstance(sym, SSym)
         value = env._global_env[sym]
@@ -244,7 +240,6 @@ class AllocInst(Inst):
     size: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         size = env[self.size]
         assert isinstance(size, SNum)
         env[self.dest] = SVect([sexp.Nil] * size.value)
@@ -260,7 +255,6 @@ class LoadInst(Inst):
     offset: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         vect = env[self.addr]
         index = env[self.offset]
         assert isinstance(vect, SVect) and isinstance(index, SNum)
@@ -280,7 +274,6 @@ class StoreInst(Inst):
     value: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         vect = env[self.addr]
         index = env[self.offset]
         assert isinstance(vect, SVect) and isinstance(index, SNum)
@@ -297,7 +290,6 @@ class LengthInst(Inst):
     addr: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         vect = env[self.addr]
         assert isinstance(vect, SVect), vect
         env[self.dest] = SNum(len(vect.items))
@@ -312,7 +304,6 @@ class ArityInst(Inst):
     func: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         func = env[self.func]
         assert isinstance(func, sexp.SFunction), func
         env[self.dest] = SNum(len(func.params))
@@ -328,7 +319,6 @@ class CallInst(Inst):
     args: List[Parameter]
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         for _ in self.run_call(env):
             pass
 
@@ -358,7 +348,6 @@ class JmpInst(Inst):
         return f"JmpInst(target={self.target.name})"
 
     def run(self, env: EvalEnv) -> BB:
-        env.stats[type(self)] += 1
         return self.target
 
     def successors(self) -> Iterable[BB]:
@@ -377,7 +366,6 @@ class BrInst(Inst):
         return (f"BrInst(cond={self.cond}, target={self.target.name})")
 
     def run(self, env: EvalEnv) -> Optional[BB]:
-        env.stats[type(self)] += 1
         res = env[self.cond]
         assert isinstance(res, sexp.SBool)
         if res.value:
@@ -400,7 +388,6 @@ class BrnInst(Inst):
         return (f"BrnInst(cond={self.cond}, target={self.target.name})")
 
     def run(self, env: EvalEnv) -> Optional[BB]:
-        env.stats[type(self)] += 1
         res = env[self.cond]
         assert isinstance(res, sexp.SBool)
         if not res.value:
@@ -419,7 +406,6 @@ class ReturnInst(Inst):
     ret: Parameter
 
     def run(self, env: EvalEnv) -> Optional[BB]:
-        env.stats[type(self)] += 1
         return ReturnBlock(f"return {self.ret}", self.ret)
 
     def __str__(self) -> str:
@@ -431,7 +417,6 @@ class TrapInst(Inst):
     message: str
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         raise Trap(self.message)
 
     def __str__(self) -> str:
@@ -443,7 +428,6 @@ class TraceInst(Inst):
     value: Parameter
 
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         print(env[self.value])
 
     def __str__(self) -> str:
@@ -453,7 +437,6 @@ class TraceInst(Inst):
 @dataclass
 class BreakpointInst(Inst):
     def run(self, env: EvalEnv) -> None:
-        env.stats[type(self)] += 1
         breakpoint()
 
     def __str__(self) -> str:
@@ -476,6 +459,7 @@ class BasicBlock(BB):
     def run(self, env: EvalEnv) -> Generator[EvalEnv, None, BB]:
         env.stats[type(self)] += 1
         for inst in self.instructions:
+            env.stats[type(inst)] += 1
             if isinstance(inst, CallInst):
                 yield from inst.run_call(env)
             else:

--- a/scheme.py
+++ b/scheme.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from typing import Dict
 
+import bytecode
 import runner
 import sexp
 
@@ -16,7 +17,7 @@ def main() -> None:
         with open(args.filename) as f:
             prog_text = f.read()
 
-    env: Dict[sexp.SSym, sexp.Value] = {}
+    env = bytecode.EvalEnv()
     runner.add_intrinsics(env)
     runner.add_builtins(env)
     runner.add_prelude(env)

--- a/scheme.py
+++ b/scheme.py
@@ -25,9 +25,6 @@ def main() -> None:
 
     if args.stats:
         print('-----')
-        for inst, count in env.stats.inst_type_count.items():
-            print(f"{inst.__name__:>10}: {count}")
-
         for name, defn in env._global_env.items():
             if name.name.startswith('__eval_expr'):
                 continue
@@ -37,6 +34,9 @@ def main() -> None:
             if count:
                 print(defn.code.format_stats(name, env.stats))
                 print()
+        print('-----')
+        for inst, count in env.stats.inst_type_count.items():
+            print(f"{inst.__name__:>10}: {count}")
 
 
 def parse_args() -> argparse.Namespace:

--- a/scheme.py
+++ b/scheme.py
@@ -23,10 +23,20 @@ def main() -> None:
     runner.add_prelude(env)
     print(runner.run(env, prog_text))
 
+    if args.stats:
+        print('-----')
+        for inst, count in env.stats.items():
+            print(f"{inst.__name__:>10}: {count}")
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('filename')
+    parser.add_argument(
+        'filename',
+        help="the script to execute, or - for stdin")
+    parser.add_argument(
+        '-s', '--stats', action='store_true',
+        help="print execution stats")
 
     return parser.parse_args()
 

--- a/scheme.py
+++ b/scheme.py
@@ -25,8 +25,18 @@ def main() -> None:
 
     if args.stats:
         print('-----')
-        for inst, count in env.stats.items():
+        for inst, count in env.stats.inst_type_count.items():
             print(f"{inst.__name__:>10}: {count}")
+
+        for name, defn in env._global_env.items():
+            if name.name.startswith('__eval_expr'):
+                continue
+            assert isinstance(defn, sexp.SFunction)
+            assert defn.code is not None
+            count = env.stats.function_count[id(defn.code)]
+            if count:
+                print(defn.code.format_stats(name, env.stats))
+                print()
 
 
 def parse_args() -> argparse.Namespace:

--- a/test_builtins.py
+++ b/test_builtins.py
@@ -1,6 +1,7 @@
 import unittest
 from typing import Dict
 
+import bytecode
 import errors
 import runner
 from runner import run
@@ -9,7 +10,7 @@ from sexp import SBool, SNum, SSym, SVect, Value
 
 class BuiltinsTestCase(unittest.TestCase):
     def test_intrinsics(self) -> None:
-        env: Dict[SSym, Value] = {}
+        env = bytecode.EvalEnv()
         runner.add_intrinsics(env)
 
         self.assertEqual(run(env, '(inst/typeof 42)'), SSym('number'))
@@ -41,7 +42,7 @@ class BuiltinsTestCase(unittest.TestCase):
         self.assertEqual(run(env, '(inst/number< -1 0)'), SBool(True))
 
     def test_builtins(self) -> None:
-        env: Dict[SSym, Value] = {}
+        env = bytecode.EvalEnv()
         runner.add_intrinsics(env)
         runner.add_builtins(env)
 
@@ -126,7 +127,7 @@ class BuiltinsTestCase(unittest.TestCase):
         )
 
     def test_prelude(self) -> None:
-        env: Dict[SSym, Value] = {}
+        env = bytecode.EvalEnv()
         runner.add_intrinsics(env)
         runner.add_builtins(env)
         runner.add_prelude(env)

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -13,7 +13,7 @@ class EmitExpressionTestCase(unittest.TestCase):
         bb_names = emit_IR.name_generator('bb')
         self.bb = bytecode.BasicBlock(next(bb_names))
         self.expr_emitter = emit_IR.ExpressionEmitter(
-            self.bb, bb_names, emit_IR.name_generator('var'), {}, {})
+            self.bb, bb_names, emit_IR.name_generator('v'), {}, {})
 
     def test_emit_int_literal(self) -> None:
         prog = sexp.parse('42')
@@ -42,7 +42,7 @@ class EmitExpressionTestCase(unittest.TestCase):
 
         expected_instrs = [
             bytecode.AllocInst(
-                bytecode.Var('var0'),
+                bytecode.Var('v0'),
                 bytecode.NumLit(sexp.SNum(0))
             )
         ]
@@ -53,7 +53,7 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse('[1 2]')
         self.expr_emitter.visit(prog)
 
-        arr_var = bytecode.Var('var0')
+        arr_var = bytecode.Var('v0')
         expected_instrs = [
             bytecode.AllocInst(
                 arr_var,
@@ -77,7 +77,7 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse("'()")
         self.expr_emitter.visit(prog)
 
-        nil_var = bytecode.Var('var0')
+        nil_var = bytecode.Var('v0')
         expected_instrs = [
             bytecode.AllocInst(
                 nil_var, bytecode.NumLit(sexp.SNum(0))
@@ -90,9 +90,9 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse("'(1 spam)")
         self.expr_emitter.visit(prog)
 
-        nil_var = bytecode.Var('var0')
-        second_pair = bytecode.Var('var1')
-        first_pair = bytecode.Var('var2')
+        nil_var = bytecode.Var('v0')
+        second_pair = bytecode.Var('v1')
+        first_pair = bytecode.Var('v2')
         expected_instrs = [
             bytecode.AllocInst(
                 nil_var, bytecode.NumLit(sexp.SNum(0))
@@ -131,11 +131,11 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse('(number? 1)')
         self.expr_emitter.visit(prog)
 
-        func_var = bytecode.Var('var0')
-        typeof_var = bytecode.Var('__typeof')
-        is_function_var = bytecode.Var('__is_func')
-        arity_var = bytecode.Var('__arity')
-        correct_arity_var = bytecode.Var('__correct_arity')
+        func_var = bytecode.Var('v0')
+        typeof_var = bytecode.Var('v1')
+        is_function_var = bytecode.Var('v2')
+        arity_var = bytecode.Var('v3')
+        correct_arity_var = bytecode.Var('v4')
         expected_instrs = [
             bytecode.LookupInst(
                 func_var, bytecode.SymLit(sexp.SSym('number?'))
@@ -150,7 +150,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 is_function_var,
                 bytecode.BasicBlock(
-                    '__non_function_trap',
+                    'non_function',
                     [bytecode.TrapInst('Attempted to call a non-function')])
             ),
 
@@ -162,13 +162,13 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 correct_arity_var,
                 bytecode.BasicBlock(
-                    '__wrong_arity_trap',
+                    'wrong_arity',
                     [bytecode.TrapInst(
                         'Call with the wrong number of arguments')])
             ),
 
             bytecode.CallInst(
-                bytecode.Var('var1'),
+                bytecode.Var('v5'),
                 func_var,
                 [bytecode.NumLit(sexp.SNum(1))]
             ),
@@ -181,10 +181,10 @@ class EmitExpressionTestCase(unittest.TestCase):
         self.expr_emitter.local_env[sexp.SSym('local_var')] = lambda_var
         self.expr_emitter.visit(prog)
 
-        typeof_var = bytecode.Var('__typeof')
-        is_function_var = bytecode.Var('__is_func')
-        arity_var = bytecode.Var('__arity')
-        correct_arity_var = bytecode.Var('__correct_arity')
+        typeof_var = bytecode.Var('v0')
+        is_function_var = bytecode.Var('v1')
+        arity_var = bytecode.Var('v2')
+        correct_arity_var = bytecode.Var('v3')
         expected_instrs = [
             bytecode.TypeofInst(typeof_var, lambda_var),
             bytecode.BinopInst(
@@ -194,7 +194,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 is_function_var,
                 bytecode.BasicBlock(
-                    '__non_function_trap',
+                    'non_function',
                     [bytecode.TrapInst('Attempted to call a non-function')])
             ),
 
@@ -206,13 +206,13 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 correct_arity_var,
                 bytecode.BasicBlock(
-                    '__wrong_arity_trap',
+                    'wrong_arity',
                     [bytecode.TrapInst(
                         'Call with the wrong number of arguments')])
             ),
 
             bytecode.CallInst(
-                bytecode.Var('var0'),
+                bytecode.Var('v4'),
                 lambda_var,
                 [bytecode.NumLit(sexp.SNum(42))]
             )
@@ -234,11 +234,11 @@ class EmitExpressionTestCase(unittest.TestCase):
             )
         )
 
-        lambda_lookup_var = bytecode.Var('var0')
-        typeof_var = bytecode.Var('__typeof')
-        is_function_var = bytecode.Var('__is_func')
-        arity_var = bytecode.Var('__arity')
-        correct_arity_var = bytecode.Var('__correct_arity')
+        lambda_lookup_var = bytecode.Var('v0')
+        typeof_var = bytecode.Var('v1')
+        is_function_var = bytecode.Var('v2')
+        arity_var = bytecode.Var('v3')
+        correct_arity_var = bytecode.Var('v4')
         expected_instrs = [
             bytecode.LookupInst(
                 lambda_lookup_var, bytecode.SymLit(sexp.SSym('__lambda0'))
@@ -252,7 +252,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 is_function_var,
                 bytecode.BasicBlock(
-                    '__non_function_trap',
+                    'non_function',
                     [bytecode.TrapInst('Attempted to call a non-function')])
             ),
 
@@ -264,13 +264,13 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 correct_arity_var,
                 bytecode.BasicBlock(
-                    '__wrong_arity_trap',
+                    'wrong_arity',
                     [bytecode.TrapInst(
                         'Call with the wrong number of arguments')])
             ),
 
             bytecode.CallInst(
-                bytecode.Var('var1'),
+                bytecode.Var('v5'),
                 lambda_lookup_var,
                 [bytecode.NumLit(sexp.SNum(42))]
             )
@@ -287,7 +287,7 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse('(if true 42 43)')
         self.expr_emitter.visit(prog)
 
-        result_var = bytecode.Var('var0')
+        result_var = bytecode.Var('v0')
         self.assertEqual(result_var, self.expr_emitter.result)
         self.assertIsNot(
             self.expr_emitter.parent_block, self.expr_emitter.end_block)
@@ -332,11 +332,11 @@ class EmitExpressionTestCase(unittest.TestCase):
         prog = sexp.parse('(if true (if false 42 43) (if true 44 45))')
         self.expr_emitter.visit(prog)
 
-        outer_result_var = bytecode.Var('var0')
+        outer_result_var = bytecode.Var('v0')
 
         outer_end_block = bytecode.BasicBlock('bb9')
 
-        then_result_var = bytecode.Var('var1')
+        then_result_var = bytecode.Var('v1')
         then_end_block = bytecode.BasicBlock(
             'bb5',
             [
@@ -363,7 +363,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             ]
         )
 
-        else_result_var = bytecode.Var('var2')
+        else_result_var = bytecode.Var('v2')
         else_end_block = bytecode.BasicBlock(
             'bb8',
             [
@@ -430,7 +430,7 @@ class EmitExpressionTestCase(unittest.TestCase):
 
         end_block = bytecode.BasicBlock('bb6')
 
-        body_result = bytecode.Var('var1')
+        body_result = bytecode.Var('v1')
 
         body_then_block = bytecode.BasicBlock(
             'bb4',
@@ -452,7 +452,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             ]
         )
 
-        condition_result = bytecode.Var('var0')
+        condition_result = bytecode.Var('v0')
         condition_end_block = bytecode.BasicBlock(
             'bb3',
             [
@@ -501,7 +501,13 @@ class EmitExpressionTestCase(unittest.TestCase):
         self.expr_emitter.visit(prog)
 
         end_block = bytecode.BasicBlock('bb3')
-        conditional_result = bytecode.Var('var1')
+        func_var = bytecode.Var('v0')
+        typeof_var = bytecode.Var('v1')
+        is_function_var = bytecode.Var('v2')
+        arity_var = bytecode.Var('v3')
+        correct_arity_var = bytecode.Var('v4')
+        conditional_result = bytecode.Var('v5')
+        call_result = bytecode.Var('v6')
 
         then_block = bytecode.BasicBlock(
             'bb1',
@@ -522,12 +528,6 @@ class EmitExpressionTestCase(unittest.TestCase):
                 bytecode.JmpInst(end_block)
             ]
         )
-
-        func_var = bytecode.Var('var0')
-        typeof_var = bytecode.Var('__typeof')
-        is_function_var = bytecode.Var('__is_func')
-        arity_var = bytecode.Var('__arity')
-        correct_arity_var = bytecode.Var('__correct_arity')
         entry_block = bytecode.BasicBlock(
             'bb0',
             [
@@ -542,7 +542,7 @@ class EmitExpressionTestCase(unittest.TestCase):
                 bytecode.BrnInst(
                     is_function_var,
                     bytecode.BasicBlock(
-                        '__non_function_trap',
+                        'non_function',
                         [bytecode.TrapInst(
                             'Attempted to call a non-function')])
                 ),
@@ -555,7 +555,7 @@ class EmitExpressionTestCase(unittest.TestCase):
                 bytecode.BrnInst(
                     correct_arity_var,
                     bytecode.BasicBlock(
-                        '__wrong_arity_trap',
+                        'wrong_arity',
                         [bytecode.TrapInst(
                             'Call with the wrong number of arguments')])
                 ),
@@ -567,7 +567,6 @@ class EmitExpressionTestCase(unittest.TestCase):
             ]
         )
 
-        call_result = bytecode.Var('var2')
         end_block.add_inst(
             bytecode.CallInst(call_result, func_var, [conditional_result]))
 
@@ -585,7 +584,12 @@ class EmitExpressionTestCase(unittest.TestCase):
         self.expr_emitter.visit(prog)
 
         end_block = bytecode.BasicBlock('bb3')
-        conditional_result = bytecode.Var('var0')
+        conditional_result = bytecode.Var('v0')
+        typeof_var = bytecode.Var('v1')
+        is_function_var = bytecode.Var('v2')
+        arity_var = bytecode.Var('v3')
+        correct_arity_var = bytecode.Var('v4')
+        call_result = bytecode.Var('v5')
 
         then_block = bytecode.BasicBlock(
             'bb1',
@@ -617,11 +621,6 @@ class EmitExpressionTestCase(unittest.TestCase):
             ]
         )
 
-        call_result = bytecode.Var('var1')
-        typeof_var = bytecode.Var('__typeof')
-        is_function_var = bytecode.Var('__is_func')
-        arity_var = bytecode.Var('__arity')
-        correct_arity_var = bytecode.Var('__correct_arity')
         call_instrs = [
             bytecode.TypeofInst(typeof_var, conditional_result),
             bytecode.BinopInst(
@@ -631,7 +630,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 is_function_var,
                 bytecode.BasicBlock(
-                    '__non_function_trap',
+                    'non_function',
                     [bytecode.TrapInst('Attempted to call a non-function')])
             ),
 
@@ -643,7 +642,7 @@ class EmitExpressionTestCase(unittest.TestCase):
             bytecode.BrnInst(
                 correct_arity_var,
                 bytecode.BasicBlock(
-                    '__wrong_arity_trap',
+                    'wrong_arity',
                     [bytecode.TrapInst(
                         'Call with the wrong number of arguments')])
             ),
@@ -718,7 +717,7 @@ class EmitFunctionDefTestCase(unittest.TestCase):
         prog = sexp.parse('(define (func) (lambda (spam) spam))')
         self.function_emitter.visit(prog)
 
-        func_ret_var = bytecode.Var('var0')
+        func_ret_var = bytecode.Var('v0')
         expected_func = bytecode.Function(
             [],
             bytecode.BasicBlock(


### PR DESCRIPTION
This adds fine-grained execution statistics, and reports them with the `--stats` flag. In order to make this more readable, it changes name generator for guard code, and de-duplicates trap blocks.