### PR TITLE
Naive JIT Specialization

### DIFF
--- a/bytecode.py
+++ b/bytecode.py
@@ -527,7 +527,6 @@ class ReturnBlock(BB):
 class Function:
     params: List[Var]
     start: BB
-    end: BB
 
     def run(self, env: EvalEnv) -> Generator[EvalEnv, None, Value]:
         assert all(p in env for p in self.params)
@@ -552,9 +551,9 @@ class Function:
         while blocks:
             block = blocks.pop()
             yield block
+            visited.add(id(block))
             for b in block.successors():
                 if id(b) not in visited:
-                    visited.add(id(b))
                     blocks.append(b)
 
     def __str__(self) -> str:

--- a/bytecode.py
+++ b/bytecode.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 from typing import (Any, Counter, Dict, Generator, Generic, Iterable, Iterator,
                     List, Optional, Set, TypeVar)
 
+import find_tail_calls
 import scheme_types
 import sexp
 from errors import Trap
@@ -97,9 +98,15 @@ class EvalEnv:
     _global_env: Dict[SSym, Value]
     stats: Stats
 
+    optimize_tail_calls: bool = False
+    naive_jit: bool = False
+
     def __init__(self,
                  local_env: Optional[Dict[Var, Value]] = None,
-                 global_env: Optional[Dict[SSym, Value]] = None):
+                 global_env: Optional[Dict[SSym, Value]] = None,
+                 optimize_tail_calls: bool = False,
+                 naive_jit: bool = False,
+                 bytecode_jit: bool = False):
         if local_env is None:
             self._local_env = {}
         else:
@@ -110,9 +117,17 @@ class EvalEnv:
             self._global_env = global_env
         self.stats = Stats()
 
+        self.optimize_tail_calls = optimize_tail_calls
+        self.naive_jit = naive_jit
+        self.bytecode_jit = bytecode_jit
+
     def copy(self) -> EvalEnv:
         """Return a shallow copy of the environment."""
-        env = EvalEnv(self._local_env.copy(), self._global_env)
+        env = EvalEnv(
+            self._local_env.copy(),
+            self._global_env,
+            naive_jit=self.naive_jit,
+            bytecode_jit=self.bytecode_jit)
         env.stats = self.stats
         return env
 
@@ -341,26 +356,62 @@ class CallInst(Inst):
     def run_call(self, env: EvalEnv) -> Generator[EvalEnv, None, None]:
         func = env[self.func]
         assert isinstance(func, sexp.SFunction)
-        if func.code is None:
-            raise NotImplementedError("JIT compiling functions!")
+        assert func.code is not None
         func_code = func.code
+
+        call_args_deducer = scheme_types.CallArgsTypeAnalyzer()
+        for arg in self.args:
+            call_args_deducer.visit(env[arg])
+
+        type_tuple = tuple(call_args_deducer.arg_types)
+        func.calls[type_tuple] += 1
+        if (not func.name.name.startswith('inst/')
+                and type_tuple not in func.specializations
+                and func.calls[type_tuple] > 1):
+            self._generate_specialization(env, func, func_code, type_tuple)
+
         func_env = env.copy()
         assert len(func_code.params) == len(self.args)
         func_env._local_env = {
             name: env[arg] for name, arg in zip(func_code.params, self.args)
         }
-        if self.specialization:
-            assert self.specialization in func.specializations
+        if self.specialization and self.specialization in func.specializations:
             specialized = func.specializations[self.specialization]
             env[self.dest] = yield from specialized.run(func_env)
         else:
             env.stats.specialization_dispatch[id(self)] += 1
-            type_tuple = tuple(env[arg].scheme_type() for arg in self.args)
             if type_tuple in func.specializations:
                 specialized = func.specializations[type_tuple]
                 env[self.dest] = yield from specialized.run(func_env)
             else:
                 env[self.dest] = yield from func_code.run(func_env)
+
+    def _generate_specialization(self, env: EvalEnv,
+                                 func: sexp.SFunction,
+                                 func_code: Function,
+                                 type_tuple: TypeTuple) -> None:
+        if env.naive_jit:
+            param_types = dict(zip(func.params, type_tuple))
+            type_analyzer = scheme_types.FunctionTypeAnalyzer(
+                param_types, env._global_env)
+            type_analyzer.visit(func)
+
+            tail_calls = None
+            if env.optimize_tail_calls:
+                tail_call_finder = find_tail_calls.TailCallFinder()
+                tail_call_finder.visit(func)
+                tail_calls = tail_call_finder.tail_calls
+
+            from emit_IR import FunctionEmitter
+            emitter = FunctionEmitter(env._global_env,
+                                      tail_calls=tail_calls,
+                                      expr_types=type_analyzer)
+            emitter.visit(func)
+
+            emitted_func = emitter.get_emitted_func()
+            func.specializations[type_tuple] = emitted_func
+        elif env.bytecode_jit:
+            raise NotImplementedError
 
     def __str__(self) -> str:
         args = ', '.join(str(arg) for arg in self.args)

--- a/bytecode.py
+++ b/bytecode.py
@@ -527,6 +527,7 @@ class ReturnBlock(BB):
 class Function:
     params: List[Var]
     start: BB
+    end: BB
 
     def run(self, env: EvalEnv) -> Generator[EvalEnv, None, Value]:
         assert all(p in env for p in self.params)

--- a/emit_IR.py
+++ b/emit_IR.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import (TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple, Set,
-                    cast)
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, cast
 
 import bytecode
 import scheme_types
@@ -471,48 +470,6 @@ class ExpressionEmitter(Visitor):
         sexp.SSym('pair?'): scheme_types.SchemeVectType(2),
         sexp.SSym('nil?'): scheme_types.SchemeVectType(0),
     }
-
-    def _is_true_bounds_check(self, assert_arg: sexp.SExp) -> bool:
-        if self._expr_types is None:
-            return False
-
-        if not isinstance(assert_arg, sexp.SCall):
-            return False
-
-        if assert_arg.func != sexp.SSym('number<'):
-            return False
-
-        if len(assert_arg.args) != 2:
-            return False
-
-        first_value = self._get_bounds_check_arg_value(assert_arg.args[0])
-        second_value = self._get_bounds_check_arg_value(assert_arg.args[1])
-
-        return (first_value is not None and second_value is not None
-                and first_value < second_value)
-
-    def _get_bounds_check_arg_value(self, arg: sexp.SExp) -> Optional[int]:
-        assert self._expr_types is not None
-        if not self._expr_types.expr_type_known(arg):
-            return None
-
-        if (isinstance(arg, sexp.SCall)
-                and arg.func == sexp.SSym('vector-length')
-                and len(arg.args) == 1):
-            vec_arg = arg.args[0]
-            if not self._expr_types.expr_type_known(vec_arg):
-                return None
-
-            vec_type = self._expr_types.get_expr_type(vec_arg)
-            return (vec_type.length if isinstance(vec_type,
-                                                  scheme_types.SchemeVectType)
-                    else None)
-
-        type_ = self._expr_types.get_expr_type(arg)
-        if isinstance(type_, scheme_types.SchemeNumType):
-            return type_.value
-
-        return None
 
     def _add_is_function_check(
             self, function_expr: bytecode.Parameter,

--- a/emit_IR.py
+++ b/emit_IR.py
@@ -102,16 +102,14 @@ class ExpressionEmitter(Visitor):
         assert not self.quoted, 'Non-primitives in quoted list unsupported'
 
         # Don't re-emit lambdas defined in a function we're specializing
-        if self._param_types:
-            return
+        if not self._param_types:
+            func_emitter = FunctionEmitter(self.global_env)
+            func_emitter.visit(func)
+            func.code = func_emitter.get_emitted_func()
 
-        func_emitter = FunctionEmitter(self.global_env)
-        func_emitter.visit(func)
-        func.code = func_emitter.get_emitted_func()
-
-        assert func.name not in self.global_env, (
-            f"Duplicate function name: {func.name}")
-        self.global_env[func.name] = func
+            assert func.name not in self.global_env, (
+                f"Duplicate function name: {func.name}")
+            self.global_env[func.name] = func
 
         lambda_var = bytecode.Var(next(self.var_names))
         lookup_lambda_instr = bytecode.LookupInst(

--- a/find_tail_calls.py
+++ b/find_tail_calls.py
@@ -9,6 +9,11 @@ from visitor import Visitor
 class TailCallData:
     call: sexp.SCall
     func_params: List[sexp.SSym] = field(default_factory=list)
+    func: Optional[sexp.SFunction] = None
+
+    def get_func(self) -> sexp.SFunction:
+        assert self.func is not None, 'func not set on TailCallData'
+        return self.func
 
     def __hash__(self) -> int:
         return hash(id(self.call))
@@ -51,4 +56,6 @@ class TailCallFinder(Visitor):
             return
 
         self._tail_calls.append(
-            TailCallData(call, list(self._current_function.params)))
+            TailCallData(call,
+                         list(self._current_function.params),
+                         self._current_function))

--- a/runner.py
+++ b/runner.py
@@ -214,12 +214,11 @@ def add_prelude(env: EvalEnv) -> None:
 eval_names = emit_IR.name_generator('__eval_expr')
 
 
-def run_code(env: EvalEnv, code: SExp,
-             optimize_tail_calls: bool = False) -> Value:
+def run_code(env: EvalEnv, code: SExp) -> Value:
     """Run a piece of code in an environment, returning its result."""
     if isinstance(code, sexp.SFunction):
         tail_calls = None
-        if optimize_tail_calls:
+        if env.optimize_tail_calls:
             tail_call_finder = TailCallFinder()
             tail_call_finder.visit(code)
             tail_calls = tail_call_finder.tail_calls
@@ -253,7 +252,7 @@ def _add_func_to_env(func: sexp.SFunction, func_emitter: FunctionEmitter,
     env._global_env[func.name] = func
 
 
-def run(env: EvalEnv, text: str, optimize_tail_calls: bool = False) -> Value:
+def run(env: EvalEnv, text: str) -> Value:
     """
     Run a piece of code in an environment, returning its result.
 
@@ -269,5 +268,5 @@ def run(env: EvalEnv, text: str, optimize_tail_calls: bool = False) -> Value:
     code = sexp.parse(text)
     result: Value = sexp.SVect([])
     for part in code:
-        result = run_code(env, part, optimize_tail_calls=optimize_tail_calls)
+        result = run_code(env, part)
     return result

--- a/runner.py
+++ b/runner.py
@@ -21,7 +21,7 @@ def add_intrinsics(eval_env: EvalEnv) -> None:
             begin.add_inst(inst)
         if return_val is not None:
             begin.add_inst(bytecode.ReturnInst(return_val))
-        code = Function(params, begin, begin)
+        code = Function(params, begin)
         param_syms = [SSym(p.name) for p in params]
         return SFunction(name, param_syms, Nil, code, False)
 

--- a/runner.py
+++ b/runner.py
@@ -21,7 +21,7 @@ def add_intrinsics(eval_env: EvalEnv) -> None:
             begin.add_inst(inst)
         if return_val is not None:
             begin.add_inst(bytecode.ReturnInst(return_val))
-        code = Function(params, begin)
+        code = Function(params, begin, begin)
         param_syms = [SSym(p.name) for p in params]
         return SFunction(name, param_syms, Nil, code, False)
 

--- a/scheme.py
+++ b/scheme.py
@@ -17,12 +17,13 @@ def main() -> None:
         with open(args.filename) as f:
             prog_text = f.read()
 
-    env = bytecode.EvalEnv()
+    env = bytecode.EvalEnv(optimize_tail_calls=args.optimize_tail_calls,
+                           naive_jit=args.naive_jit,
+                           bytecode_jit=args.bytecode_jit)
     runner.add_intrinsics(env)
     runner.add_builtins(env)
     runner.add_prelude(env)
-    print(runner.run(env, prog_text,
-                     optimize_tail_calls=args.transform_tail_calls))
+    print(runner.run(env, prog_text))
 
     if args.stats:
         print('-----')
@@ -50,7 +51,14 @@ def parse_args() -> argparse.Namespace:
         help="print execution stats")
 
     parser.add_argument(
-        '--transform_tail_calls', '-t', action='store_true', default=False)
+        '--optimize_tail_calls', '-t', action='store_true', default=False)
+
+    parser.add_argument(
+        '--naive_jit', '-n', action='store_true', default=False)
+
+    parser.add_argument(
+        '--bytecode_jit', '-b', action='store_true', default=False
+    )
 
     return parser.parse_args()
 

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -88,13 +88,13 @@ class FunctionTypeAnalyzer(Visitor):
     def get_expr_types(self) -> Dict[SExpWrapper, SchemeObjectType]:
         return copy.copy(self._expr_types)
 
-    def _get_expr_type(self, expr: sexp.SExp) -> SchemeObjectType:
+    def get_expr_type(self, expr: sexp.SExp) -> SchemeObjectType:
         return self._expr_types[SExpWrapper(expr)]
 
     def _set_expr_type(self, expr: sexp.SExp, type_: SchemeObjectType) -> None:
         self._expr_types[SExpWrapper(expr)] = type_
 
-    def _expr_type_known(self, expr: sexp.SExp) -> bool:
+    def expr_type_known(self, expr: sexp.SExp) -> bool:
         return SExpWrapper(expr) in self._expr_types
 
     def visit_SFunction(self, func: sexp.SFunction) -> None:
@@ -106,7 +106,7 @@ class FunctionTypeAnalyzer(Visitor):
 
             self._function_type = SchemeFunctionType(
                 len(func.params),
-                self._get_expr_type(list(func.body)[-1])
+                self.get_expr_type(list(func.body)[-1])
             )
             self._set_expr_type(func, self._function_type)
 
@@ -139,8 +139,8 @@ class FunctionTypeAnalyzer(Visitor):
 
     def visit_SCall(self, call: sexp.SCall) -> None:
         super().visit_SCall(call)
-        if self._expr_type_known(call.func):
-            func_type = self._get_expr_type(call.func)
+        if self.expr_type_known(call.func):
+            func_type = self.get_expr_type(call.func)
             if isinstance(func_type, SchemeFunctionType):
                 self._set_expr_type(call, func_type.return_type)
             else:
@@ -151,8 +151,8 @@ class FunctionTypeAnalyzer(Visitor):
     def visit_SConditional(self, cond: sexp.SConditional) -> None:
         super().visit_SConditional(cond)
 
-        then_type = self._get_expr_type(cond.then_expr)
-        else_type = self._get_expr_type(cond.else_expr)
+        then_type = self.get_expr_type(cond.then_expr)
+        else_type = self.get_expr_type(cond.else_expr)
         if then_type == else_type:
             self._set_expr_type(cond, then_type)
         else:

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Type
 
 import sexp
+from visitor import Visitor
 
 
 @dataclass(frozen=True)
@@ -13,7 +14,7 @@ SchemeObject = SchemeObjectType()
 
 
 @dataclass(frozen=True)
-class SchemeBottomType:
+class SchemeBottomType(SchemeObjectType):
     pass
 
 
@@ -60,3 +61,178 @@ class SchemeQuotedType(SchemeObjectType):
 
 
 TypeTuple = Tuple[SchemeObjectType, ...]
+@dataclass
+class SExpWrapper:
+    expr: sexp.SExp
+
+    def __eq__(self, other: Any) -> bool:
+        return hash(self) == hash(other)
+
+    def __hash__(self) -> int:
+        return hash(id(self.expr))
+
+
+class FunctionTypeAnalyzer(Visitor):
+    def __init__(self, param_types: Dict[sexp.SSym, SchemeObjectType]):
+        self._param_types = param_types
+        self._expr_types: Dict[SExpWrapper, SchemeObjectType] = {}
+
+    def visit_SFunction(self, func: sexp.SFunction) -> None:
+        if func.is_lambda:
+            self._expr_types[SExpWrapper(func)] = (
+                SchemeFunctionType(len(func.params)))
+            # Lambda bodies will be analyzed separately when they're called
+        else:
+            super().visit(func.body)
+
+    def visit_SNum(self, num: sexp.SNum) -> None:
+        self._expr_types[SExpWrapper(num)] = SchemeNumType()
+
+    def visit_SBool(self, sbool: sexp.SBool) -> None:
+        self._expr_types[SExpWrapper(sbool)] = SchemeBoolType()
+
+    def visit_SSym(self, sym: sexp.SSym) -> None:
+        if sym in self._param_types:
+            self._expr_types[SExpWrapper(sym)] = self._param_types[sym]
+        elif sym in _BUILTINS_RETURN_TYPES:
+            self._expr_types[SExpWrapper(sym)] = _BUILTINS_RETURN_TYPES[sym]
+        elif sym in _BUILTINS_FUNC_TYPES:
+            self._expr_types[SExpWrapper(sym)] = _BUILTINS_FUNC_TYPES[sym]
+        else:
+            self._expr_types[SExpWrapper(sym)] = SchemeSym
+
+    def visit_SVect(self, vect: sexp.SVect) -> None:
+        self._expr_types[SExpWrapper(vect)] = SchemeVectType(len(vect.items))
+
+    def visit_Quote(self, quote: sexp.Quote) -> None:
+        type_: SchemeObjectType
+        if isinstance(quote.expr, sexp.SPair) and quote.expr.is_list():
+            # Quoted lists are turned into pairs
+            type_ = SchemeVectType(2)
+        else:
+            type_ = SchemeQuotedType(type(quote.expr))
+
+        self._expr_types[SExpWrapper(quote)] = type_
+
+    def visit_SCall(self, call: sexp.SCall) -> None:
+        super().visit_SCall(call)
+        assert False, 'fixme: builtin func return types'
+
+    def visit_SConditional(self, cond: sexp.SConditional) -> None:
+        super().visit_SConditional(cond)
+
+        then_type = self._expr_types[SExpWrapper(cond.then_expr)]
+        else_type = self._expr_types[SExpWrapper(cond.else_expr)]
+        if then_type == else_type:
+            self._expr_types[SExpWrapper(cond)] = then_type
+        else:
+            self._expr_types[SExpWrapper(cond)] = SchemeObjectType()
+
+
+_BUILTINS_RETURN_TYPES: Dict[sexp.SSym, SchemeObjectType] = {
+    sexp.SSym('inst/typeof'): SchemeSym,
+    sexp.SSym('inst/trap'): SchemeBottom,
+    sexp.SSym('inst/trace'): SchemeNum,
+    sexp.SSym('inst/breakpoint'): SchemeNum,
+    sexp.SSym('inst/alloc'): SchemeVectType(None),
+    sexp.SSym('inst/load'): SchemeObject,
+    sexp.SSym('inst/store'): SchemeVectType(None),
+    sexp.SSym('inst/length'): SchemeNum,
+
+    sexp.SSym('inst/+'): SchemeNum,
+    sexp.SSym('inst/-'): SchemeNum,
+    sexp.SSym('inst/*'): SchemeNum,
+    sexp.SSym('inst//'): SchemeNum,
+    sexp.SSym('inst/%'): SchemeNum,
+    sexp.SSym('inst/number='): SchemeBool,
+    sexp.SSym('inst/symbol='): SchemeBool,
+    sexp.SSym('inst/pointer='): SchemeBool,
+    sexp.SSym('inst/number<'): SchemeBool,
+
+    sexp.SSym('trap'): SchemeBottom,
+    sexp.SSym('trace'): SchemeNum,
+    sexp.SSym('breakpoint'): SchemeNum,
+    sexp.SSym('assert'): SchemeNum,
+    sexp.SSym('typeof'): SchemeSym,
+    sexp.SSym('not'): SchemeBool,
+
+    sexp.SSym('number?'): SchemeBool,
+    sexp.SSym('symbol?'): SchemeBool,
+    sexp.SSym('vector?'): SchemeBool,
+    sexp.SSym('function?'): SchemeBool,
+    sexp.SSym('bool?'): SchemeBool,
+    sexp.SSym('pair?'): SchemeBool,
+    sexp.SSym('nil?'): SchemeBool,
+
+    sexp.SSym('+'): SchemeNum,
+    sexp.SSym('-'): SchemeNum,
+    sexp.SSym('*'): SchemeNum,
+    sexp.SSym('/'): SchemeNum,
+    sexp.SSym('%'): SchemeNum,
+
+    sexp.SSym('pointer='): SchemeBool,
+    sexp.SSym('symbol='): SchemeBool,
+    sexp.SSym('number='): SchemeBool,
+    sexp.SSym('number<'): SchemeBool,
+
+    sexp.SSym('vector-length'): SchemeNum,
+    sexp.SSym('vector-index'): SchemeObject,
+
+    sexp.SSym('vector-set!'): SchemeVectType(None),
+    sexp.SSym('vector-make/recur'): SchemeVectType(None),
+    sexp.SSym('vector-make'): SchemeVectType(None),
+}
+
+_BUILTINS_FUNC_TYPES: Dict[sexp.SSym, SchemeObjectType] = {
+    sexp.SSym('inst/typeof'):  SchemeFunctionType(1),
+    sexp.SSym('inst/trap'): SchemeFunctionType(0),
+    sexp.SSym('inst/trace'): SchemeFunctionType(1),
+    sexp.SSym('inst/breakpoint'): SchemeFunctionType(0),
+    sexp.SSym('inst/alloc'): SchemeFunctionType(1),
+    sexp.SSym('inst/load'): SchemeFunctionType(2),
+    sexp.SSym('inst/store'): SchemeFunctionType(3),
+    sexp.SSym('inst/length'): SchemeFunctionType(1),
+
+    sexp.SSym('inst/+'): SchemeFunctionType(2),
+    sexp.SSym('inst/-'): SchemeFunctionType(2),
+    sexp.SSym('inst/*'): SchemeFunctionType(2),
+    sexp.SSym('inst//'): SchemeFunctionType(2),
+    sexp.SSym('inst/%'): SchemeFunctionType(2),
+    sexp.SSym('inst/number='): SchemeFunctionType(2),
+    sexp.SSym('inst/symbol='): SchemeFunctionType(2),
+    sexp.SSym('inst/pointer='): SchemeFunctionType(2),
+    sexp.SSym('inst/number<'): SchemeFunctionType(2),
+
+    sexp.SSym('trap'): SchemeFunctionType(0),
+    sexp.SSym('trace'): SchemeFunctionType(1),
+    sexp.SSym('breakpoint'): SchemeFunctionType(0),
+    sexp.SSym('assert'): SchemeFunctionType(1),
+    sexp.SSym('typeof'): SchemeFunctionType(1),
+    sexp.SSym('not'): SchemeFunctionType(1),
+
+    sexp.SSym('number?'): SchemeFunctionType(1),
+    sexp.SSym('symbol?'): SchemeFunctionType(1),
+    sexp.SSym('vector?'): SchemeFunctionType(1),
+    sexp.SSym('function?'): SchemeFunctionType(1),
+    sexp.SSym('bool?'): SchemeFunctionType(1),
+    sexp.SSym('pair?'): SchemeFunctionType(1),
+    sexp.SSym('nil?'): SchemeFunctionType(1),
+
+    sexp.SSym('+'): SchemeFunctionType(2),
+    sexp.SSym('-'): SchemeFunctionType(2),
+    sexp.SSym('*'): SchemeFunctionType(2),
+    sexp.SSym('/'): SchemeFunctionType(2),
+    sexp.SSym('%'): SchemeFunctionType(2),
+
+    sexp.SSym('pointer='): SchemeFunctionType(2),
+    sexp.SSym('symbol='): SchemeFunctionType(2),
+    sexp.SSym('number='): SchemeFunctionType(2),
+    sexp.SSym('number<'): SchemeFunctionType(2),
+
+    sexp.SSym('vector-length'): SchemeFunctionType(1),
+    sexp.SSym('vector-index'): SchemeFunctionType(2),
+
+    sexp.SSym('vector-set!'): SchemeFunctionType(3),
+    sexp.SSym('vector-make/recur'): SchemeFunctionType(4),
+    sexp.SSym('vector-make'): SchemeFunctionType(2),
+}

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -37,13 +37,6 @@ SchemeBottom = SchemeBottomType()
 @dataclass(frozen=True)
 class SchemeNumType(SchemeObjectType):
     pass
-    # value: Optional[int] = None
-
-    # def join_with(self, other: object) -> SchemeObjectType:
-    #     if isinstance(other, SchemeNumType):
-    #         return self if self.value == other.value else SchemeNum
-
-    #     return super().join_with(other)
 
 
 SchemeNum = SchemeNumType()
@@ -52,13 +45,6 @@ SchemeNum = SchemeNumType()
 @dataclass(frozen=True)
 class SchemeBoolType(SchemeObjectType):
     pass
-    # value: Optional[bool] = None
-
-    # def join_with(self, other: object) -> SchemeObjectType:
-    #     if isinstance(other, SchemeBoolType):
-    #         return self if self.value == other.value else SchemeBool
-
-    #     return super().join_with(other)
 
 
 SchemeBool = SchemeBoolType()
@@ -67,13 +53,6 @@ SchemeBool = SchemeBoolType()
 @dataclass(frozen=True)
 class SchemeSymType(SchemeObjectType):
     pass
-    # value: Optional[str] = None
-
-    # def join_with(self, other: object) -> SchemeObjectType:
-    #     if isinstance(other, SchemeBoolType):
-    #         return self if self.value == other.value else SchemeSym
-
-    #     return super().join_with(other)
 
 
 SchemeSym = SchemeSymType()
@@ -229,16 +208,9 @@ class FunctionTypeAnalyzer(Visitor):
     def visit_SConditional(self, cond: sexp.SConditional) -> None:
         super().visit_SConditional(cond)
 
-        conditional_type = self.get_expr_type(cond.test)
         then_type = self.get_expr_type(cond.then_expr)
         else_type = self.get_expr_type(cond.else_expr)
-        if (not isinstance(conditional_type, SchemeBoolType)
-                or conditional_type.value is None):
-            self._set_expr_type(cond, then_type.join_with(else_type))
-        elif conditional_type.value:
-            self._set_expr_type(cond, then_type)
-        else:
-            self._set_expr_type(cond, else_type)
+        self._set_expr_type(cond, then_type.join_with(else_type))
 
 
 _BUILTINS_FUNC_TYPES: Dict[sexp.SSym, SchemeObjectType] = {

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -1,7 +1,6 @@
 import copy
 from dataclasses import dataclass
-
-from typing import Any, Dict, Mapping, Optional, Type, cast
+from typing import Any, Dict, Mapping, Optional, Tuple, Type, cast
 
 import sexp
 from visitor import Visitor
@@ -64,6 +63,8 @@ class SchemeQuotedType(SchemeObjectType):
 
 
 TypeTuple = Tuple[SchemeObjectType, ...]
+
+
 @dataclass
 class SExpWrapper:
     expr: sexp.SExp

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from typing import Dict, Mapping, Optional, Tuple, Type, cast
 
 import sexp
@@ -61,6 +61,13 @@ SchemeSym = SchemeSymType()
 @dataclass(frozen=True)
 class SchemeVectType(SchemeObjectType):
     length: Optional[int]
+
+    def __init__(self, length: Optional[int]):
+        # https://docs.python.org/3/library/dataclasses.html#frozen-instances
+        object.__setattr__(
+            self,
+            'length',
+            None if length is not None and length > 4 else length)
 
     def __lt__(self, other: object) -> bool:
         if isinstance(other, SchemeVectType):

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -123,6 +123,8 @@ class FunctionTypeAnalyzer(Visitor):
             self._set_expr_type(func, SchemeFunctionType(len(func.params)))
             # Lambda bodies will be analyzed separately when they're called
         else:
+            for param in func.params:
+                super().visit(param)
             super().visit(func.body)
 
             self._function_type = SchemeFunctionType(

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -8,7 +8,8 @@ from visitor import Visitor
 
 @dataclass(frozen=True)
 class SchemeObjectType:
-    pass
+    def __lt__(self, other: Any) -> bool:
+        return issubclass(type(self), type(other))
 
 
 SchemeObject = SchemeObjectType()
@@ -50,11 +51,26 @@ SchemeSym = SchemeSymType()
 class SchemeVectType(SchemeObjectType):
     length: Optional[int]
 
+    def __lt__(self, other: Any) -> bool:
+        if isinstance(other, SchemeVectType):
+            return other.length is None or self.length == other.length
+
+        return super().__lt__(other)
+
 
 @dataclass(frozen=True)
 class SchemeFunctionType(SchemeObjectType):
     arity: Optional[int]
     return_type: SchemeObjectType = SchemeObject
+
+    def __lt__(self, other: Any) -> bool:
+        if isinstance(other, SchemeFunctionType):
+            return (
+                (other.arity is None or self.arity == other.arity)
+                and self.return_type < other.return_type
+            )
+
+        return super().__lt__(other)
 
 
 @dataclass(frozen=True)

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -1,3 +1,4 @@
+import copy
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Type
 
@@ -53,6 +54,7 @@ class SchemeVectType(SchemeObjectType):
 @dataclass(frozen=True)
 class SchemeFunctionType(SchemeObjectType):
     arity: Optional[int]
+    return_type: SchemeObjectType = SchemeObject
 
 
 @dataclass(frozen=True)
@@ -73,36 +75,57 @@ class SExpWrapper:
 
 
 class FunctionTypeAnalyzer(Visitor):
-    def __init__(self, param_types: Dict[sexp.SSym, SchemeObjectType]):
+    def __init__(self, param_types: Mapping[sexp.SSym, SchemeObjectType]):
         self._param_types = param_types
         self._expr_types: Dict[SExpWrapper, SchemeObjectType] = {}
 
+        self._function_type: Optional[SchemeFunctionType] = None
+
+    def get_function_type(self) -> SchemeFunctionType:
+        assert self._function_type is not None
+        return self._function_type
+
+    def get_expr_types(self) -> Dict[SExpWrapper, SchemeObjectType]:
+        return copy.copy(self._expr_types)
+
+    def _get_expr_type(self, expr: sexp.SExp) -> SchemeObjectType:
+        return self._expr_types[SExpWrapper(expr)]
+
+    def _set_expr_type(self, expr: sexp.SExp, type_: SchemeObjectType) -> None:
+        self._expr_types[SExpWrapper(expr)] = type_
+
+    def _expr_type_known(self, expr: sexp.SExp) -> bool:
+        return SExpWrapper(expr) in self._expr_types
+
     def visit_SFunction(self, func: sexp.SFunction) -> None:
         if func.is_lambda:
-            self._expr_types[SExpWrapper(func)] = (
-                SchemeFunctionType(len(func.params)))
+            self._set_expr_type(func, SchemeFunctionType(len(func.params)))
             # Lambda bodies will be analyzed separately when they're called
         else:
             super().visit(func.body)
 
+            self._function_type = SchemeFunctionType(
+                len(func.params),
+                self._get_expr_type(list(func.body)[-1])
+            )
+            self._set_expr_type(func, self._function_type)
+
     def visit_SNum(self, num: sexp.SNum) -> None:
-        self._expr_types[SExpWrapper(num)] = SchemeNumType()
+        self._set_expr_type(num, SchemeNumType())
 
     def visit_SBool(self, sbool: sexp.SBool) -> None:
-        self._expr_types[SExpWrapper(sbool)] = SchemeBoolType()
+        self._set_expr_type(sbool, SchemeBoolType())
 
     def visit_SSym(self, sym: sexp.SSym) -> None:
         if sym in self._param_types:
-            self._expr_types[SExpWrapper(sym)] = self._param_types[sym]
-        elif sym in _BUILTINS_RETURN_TYPES:
-            self._expr_types[SExpWrapper(sym)] = _BUILTINS_RETURN_TYPES[sym]
+            self._set_expr_type(sym, self._param_types[sym])
         elif sym in _BUILTINS_FUNC_TYPES:
-            self._expr_types[SExpWrapper(sym)] = _BUILTINS_FUNC_TYPES[sym]
+            self._set_expr_type(sym, _BUILTINS_FUNC_TYPES[sym])
         else:
-            self._expr_types[SExpWrapper(sym)] = SchemeSym
+            self._set_expr_type(sym, SchemeObject)
 
     def visit_SVect(self, vect: sexp.SVect) -> None:
-        self._expr_types[SExpWrapper(vect)] = SchemeVectType(len(vect.items))
+        self._set_expr_type(vect, SchemeVectType(len(vect.items)))
 
     def visit_Quote(self, quote: sexp.Quote) -> None:
         type_: SchemeObjectType
@@ -112,127 +135,81 @@ class FunctionTypeAnalyzer(Visitor):
         else:
             type_ = SchemeQuotedType(type(quote.expr))
 
-        self._expr_types[SExpWrapper(quote)] = type_
+        self._set_expr_type(quote, type_)
 
     def visit_SCall(self, call: sexp.SCall) -> None:
         super().visit_SCall(call)
-        assert False, 'fixme: builtin func return types'
+        if self._expr_type_known(call.func):
+            func_type = self._get_expr_type(call.func)
+            if isinstance(func_type, SchemeFunctionType):
+                self._set_expr_type(call, func_type.return_type)
+            else:
+                self._set_expr_type(call, SchemeObject)
+        else:
+            self._set_expr_type(call, SchemeObject)
 
     def visit_SConditional(self, cond: sexp.SConditional) -> None:
         super().visit_SConditional(cond)
 
-        then_type = self._expr_types[SExpWrapper(cond.then_expr)]
-        else_type = self._expr_types[SExpWrapper(cond.else_expr)]
+        then_type = self._get_expr_type(cond.then_expr)
+        else_type = self._get_expr_type(cond.else_expr)
         if then_type == else_type:
-            self._expr_types[SExpWrapper(cond)] = then_type
+            self._set_expr_type(cond, then_type)
         else:
-            self._expr_types[SExpWrapper(cond)] = SchemeObjectType()
+            self._set_expr_type(cond, SchemeObjectType())
 
-
-_BUILTINS_RETURN_TYPES: Dict[sexp.SSym, SchemeObjectType] = {
-    sexp.SSym('inst/typeof'): SchemeSym,
-    sexp.SSym('inst/trap'): SchemeBottom,
-    sexp.SSym('inst/trace'): SchemeNum,
-    sexp.SSym('inst/breakpoint'): SchemeNum,
-    sexp.SSym('inst/alloc'): SchemeVectType(None),
-    sexp.SSym('inst/load'): SchemeObject,
-    sexp.SSym('inst/store'): SchemeVectType(None),
-    sexp.SSym('inst/length'): SchemeNum,
-
-    sexp.SSym('inst/+'): SchemeNum,
-    sexp.SSym('inst/-'): SchemeNum,
-    sexp.SSym('inst/*'): SchemeNum,
-    sexp.SSym('inst//'): SchemeNum,
-    sexp.SSym('inst/%'): SchemeNum,
-    sexp.SSym('inst/number='): SchemeBool,
-    sexp.SSym('inst/symbol='): SchemeBool,
-    sexp.SSym('inst/pointer='): SchemeBool,
-    sexp.SSym('inst/number<'): SchemeBool,
-
-    sexp.SSym('trap'): SchemeBottom,
-    sexp.SSym('trace'): SchemeNum,
-    sexp.SSym('breakpoint'): SchemeNum,
-    sexp.SSym('assert'): SchemeNum,
-    sexp.SSym('typeof'): SchemeSym,
-    sexp.SSym('not'): SchemeBool,
-
-    sexp.SSym('number?'): SchemeBool,
-    sexp.SSym('symbol?'): SchemeBool,
-    sexp.SSym('vector?'): SchemeBool,
-    sexp.SSym('function?'): SchemeBool,
-    sexp.SSym('bool?'): SchemeBool,
-    sexp.SSym('pair?'): SchemeBool,
-    sexp.SSym('nil?'): SchemeBool,
-
-    sexp.SSym('+'): SchemeNum,
-    sexp.SSym('-'): SchemeNum,
-    sexp.SSym('*'): SchemeNum,
-    sexp.SSym('/'): SchemeNum,
-    sexp.SSym('%'): SchemeNum,
-
-    sexp.SSym('pointer='): SchemeBool,
-    sexp.SSym('symbol='): SchemeBool,
-    sexp.SSym('number='): SchemeBool,
-    sexp.SSym('number<'): SchemeBool,
-
-    sexp.SSym('vector-length'): SchemeNum,
-    sexp.SSym('vector-index'): SchemeObject,
-
-    sexp.SSym('vector-set!'): SchemeVectType(None),
-    sexp.SSym('vector-make/recur'): SchemeVectType(None),
-    sexp.SSym('vector-make'): SchemeVectType(None),
-}
 
 _BUILTINS_FUNC_TYPES: Dict[sexp.SSym, SchemeObjectType] = {
-    sexp.SSym('inst/typeof'):  SchemeFunctionType(1),
-    sexp.SSym('inst/trap'): SchemeFunctionType(0),
-    sexp.SSym('inst/trace'): SchemeFunctionType(1),
-    sexp.SSym('inst/breakpoint'): SchemeFunctionType(0),
-    sexp.SSym('inst/alloc'): SchemeFunctionType(1),
-    sexp.SSym('inst/load'): SchemeFunctionType(2),
-    sexp.SSym('inst/store'): SchemeFunctionType(3),
-    sexp.SSym('inst/length'): SchemeFunctionType(1),
+    sexp.SSym('inst/typeof'):  SchemeFunctionType(1, SchemeSym),
+    sexp.SSym('inst/trap'): SchemeFunctionType(0, SchemeBottom),
+    sexp.SSym('inst/trace'): SchemeFunctionType(1, SchemeNum),
+    sexp.SSym('inst/breakpoint'): SchemeFunctionType(0, SchemeNum),
+    sexp.SSym('inst/alloc'): SchemeFunctionType(1, SchemeVectType(None)),
+    sexp.SSym('inst/load'): SchemeFunctionType(2, SchemeObject),
+    sexp.SSym('inst/store'): SchemeFunctionType(3, SchemeVectType(None)),
+    sexp.SSym('inst/length'): SchemeFunctionType(1, SchemeNum),
 
-    sexp.SSym('inst/+'): SchemeFunctionType(2),
-    sexp.SSym('inst/-'): SchemeFunctionType(2),
-    sexp.SSym('inst/*'): SchemeFunctionType(2),
-    sexp.SSym('inst//'): SchemeFunctionType(2),
-    sexp.SSym('inst/%'): SchemeFunctionType(2),
-    sexp.SSym('inst/number='): SchemeFunctionType(2),
-    sexp.SSym('inst/symbol='): SchemeFunctionType(2),
-    sexp.SSym('inst/pointer='): SchemeFunctionType(2),
-    sexp.SSym('inst/number<'): SchemeFunctionType(2),
+    sexp.SSym('inst/+'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('inst/-'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('inst/*'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('inst//'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('inst/%'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('inst/number='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('inst/symbol='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('inst/pointer='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('inst/number<'): SchemeFunctionType(2, SchemeBool),
 
-    sexp.SSym('trap'): SchemeFunctionType(0),
-    sexp.SSym('trace'): SchemeFunctionType(1),
-    sexp.SSym('breakpoint'): SchemeFunctionType(0),
-    sexp.SSym('assert'): SchemeFunctionType(1),
-    sexp.SSym('typeof'): SchemeFunctionType(1),
-    sexp.SSym('not'): SchemeFunctionType(1),
+    sexp.SSym('trap'): SchemeFunctionType(0, SchemeBottom),
+    sexp.SSym('trace'): SchemeFunctionType(1, SchemeNum),
+    sexp.SSym('breakpoint'): SchemeFunctionType(0, SchemeNum),
+    sexp.SSym('assert'): SchemeFunctionType(1, SchemeNum),
+    sexp.SSym('typeof'): SchemeFunctionType(1, SchemeSym),
+    sexp.SSym('not'): SchemeFunctionType(1, SchemeBool),
 
-    sexp.SSym('number?'): SchemeFunctionType(1),
-    sexp.SSym('symbol?'): SchemeFunctionType(1),
-    sexp.SSym('vector?'): SchemeFunctionType(1),
-    sexp.SSym('function?'): SchemeFunctionType(1),
-    sexp.SSym('bool?'): SchemeFunctionType(1),
-    sexp.SSym('pair?'): SchemeFunctionType(1),
-    sexp.SSym('nil?'): SchemeFunctionType(1),
+    sexp.SSym('number?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('symbol?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('vector?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('function?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('bool?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('pair?'): SchemeFunctionType(1, SchemeBool),
+    sexp.SSym('nil?'): SchemeFunctionType(1, SchemeBool),
 
-    sexp.SSym('+'): SchemeFunctionType(2),
-    sexp.SSym('-'): SchemeFunctionType(2),
-    sexp.SSym('*'): SchemeFunctionType(2),
-    sexp.SSym('/'): SchemeFunctionType(2),
-    sexp.SSym('%'): SchemeFunctionType(2),
+    sexp.SSym('+'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('-'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('*'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('/'): SchemeFunctionType(2, SchemeNum),
+    sexp.SSym('%'): SchemeFunctionType(2, SchemeNum),
 
-    sexp.SSym('pointer='): SchemeFunctionType(2),
-    sexp.SSym('symbol='): SchemeFunctionType(2),
-    sexp.SSym('number='): SchemeFunctionType(2),
-    sexp.SSym('number<'): SchemeFunctionType(2),
+    sexp.SSym('pointer='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('symbol='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('number='): SchemeFunctionType(2, SchemeBool),
+    sexp.SSym('number<'): SchemeFunctionType(2, SchemeBool),
 
-    sexp.SSym('vector-length'): SchemeFunctionType(1),
-    sexp.SSym('vector-index'): SchemeFunctionType(2),
+    sexp.SSym('vector-length'): SchemeFunctionType(1, SchemeNum),
+    sexp.SSym('vector-index'): SchemeFunctionType(2, SchemeObject),
 
-    sexp.SSym('vector-set!'): SchemeFunctionType(3),
-    sexp.SSym('vector-make/recur'): SchemeFunctionType(4),
-    sexp.SSym('vector-make'): SchemeFunctionType(2),
+    sexp.SSym('vector-set!'): SchemeFunctionType(3, SchemeVectType(None)),
+    sexp.SSym('vector-make/recur'): (
+        SchemeFunctionType(4, SchemeVectType(None))),
+    sexp.SSym('vector-make'): SchemeFunctionType(2, SchemeVectType(None)),
 }

--- a/scheme_types.py
+++ b/scheme_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import InitVar, dataclass, field
-from typing import Dict, Mapping, Optional, Tuple, Type, cast
+from typing import Dict, List, Mapping, Optional, Tuple, Type, cast
 
 import sexp
 from visitor import Visitor
@@ -123,6 +123,26 @@ class SExpWrapper:
 
     def __hash__(self) -> int:
         return hash(id(self.expr))
+
+
+class CallArgsTypeAnalyzer(Visitor):
+    def __init__(self) -> None:
+        self.arg_types: List[SchemeObjectType] = []
+
+    def visit_SFunction(self, func: sexp.SFunction) -> None:
+        self.arg_types.append(SchemeFunctionType(len(func.params)))
+
+    def visit_SNum(self, num: sexp.SNum) -> None:
+        self.arg_types.append(SchemeNum)
+
+    def visit_SBool(self, sbool: sexp.SBool) -> None:
+        self.arg_types.append(SchemeBool)
+
+    def visit_SSym(self, sym: sexp.SSym) -> None:
+        self.arg_types.append(SchemeSym)
+
+    def visit_SVect(self, vect: sexp.SVect) -> None:
+        self.arg_types.append(SchemeVectType(len(vect.items)))
 
 
 class FunctionTypeAnalyzer(Visitor):

--- a/sexp.py
+++ b/sexp.py
@@ -50,7 +50,7 @@ class SNum(Value):
         return self.value
 
     def scheme_type(self) -> scheme_types.SchemeNumType:
-        return scheme_types.SchemeNumType(value)
+        return scheme_types.SchemeNumType(self.value)
 
 
 @dataclass(frozen=True)
@@ -68,7 +68,7 @@ class SBool(Value):
         return id(self.value)
 
     def scheme_type(self) -> scheme_types.SchemeBoolType:
-        return scheme_types.SchemeBool
+        return scheme_types.SchemeBoolType(self.value)
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,7 @@ class SSym(Value):
         return id(self.name)
 
     def scheme_type(self) -> scheme_types.SchemeSymType:
-        return scheme_types.SchemeSym
+        return scheme_types.SchemeSymType(self.name)
 
 
 @dataclass(frozen=True)

--- a/sexp.py
+++ b/sexp.py
@@ -50,7 +50,7 @@ class SNum(Value):
         return self.value
 
     def scheme_type(self) -> scheme_types.SchemeNumType:
-        return scheme_types.SchemeNumType(self.value)
+        return scheme_types.SchemeNum#Type(self.value)
 
 
 @dataclass(frozen=True)
@@ -68,7 +68,7 @@ class SBool(Value):
         return id(self.value)
 
     def scheme_type(self) -> scheme_types.SchemeBoolType:
-        return scheme_types.SchemeBoolType(self.value)
+        return scheme_types.SchemeBool#Type(self.value)
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,7 @@ class SSym(Value):
         return id(self.name)
 
     def scheme_type(self) -> scheme_types.SchemeSymType:
-        return scheme_types.SchemeSymType(self.name)
+        return scheme_types.SchemeSym#Type(self.name)
 
 
 @dataclass(frozen=True)

--- a/sexp.py
+++ b/sexp.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import (TYPE_CHECKING, Dict, Iterator, List, Optional, Sequence,
-                    Tuple, Union, cast)
-
-import scheme_types
+from typing import (TYPE_CHECKING, Counter, Dict, Iterator, List, Optional,
+                    Sequence, Tuple, Union, cast)
 
 if TYPE_CHECKING:
     import bytecode
@@ -27,10 +25,6 @@ class Value(SExp):
     def address(self) -> int:
         ...
 
-    @abstractmethod
-    def scheme_type(self) -> scheme_types.SchemeObjectType:
-        ...
-
 
 @dataclass(frozen=True, order=True)
 class SNum(Value):
@@ -49,9 +43,6 @@ class SNum(Value):
     def address(self) -> int:
         return self.value
 
-    def scheme_type(self) -> scheme_types.SchemeNumType:
-        return scheme_types.SchemeNum
-
 
 @dataclass(frozen=True)
 class SBool(Value):
@@ -66,9 +57,6 @@ class SBool(Value):
 
     def address(self) -> int:
         return id(self.value)
-
-    def scheme_type(self) -> scheme_types.SchemeBoolType:
-        return scheme_types.SchemeBool
 
 
 @dataclass(frozen=True)
@@ -87,9 +75,6 @@ class SSym(Value):
 
     def address(self) -> int:
         return id(self.name)
-
-    def scheme_type(self) -> scheme_types.SchemeSymType:
-        return scheme_types.SchemeSym
 
 
 @dataclass(frozen=True)
@@ -116,9 +101,6 @@ class SVect(Value):
 
     def address(self) -> int:
         return id(self.items)
-
-    def scheme_type(self) -> scheme_types.SchemeVectType:
-        return scheme_types.SchemeVectType(len(self.items))
 
 
 @dataclass(frozen=True)
@@ -246,6 +228,8 @@ class SFunction(Value):
     code: Optional[bytecode.Function] = None
     is_lambda: bool = False
 
+    calls: Counter[TypeTuple] = field(default_factory=Counter)
+
     specializations: Dict[TypeTuple, bytecode.Function] = \
         field(default_factory=dict)
 
@@ -254,9 +238,6 @@ class SFunction(Value):
 
     def address(self) -> int:
         return id(self.code)
-
-    def scheme_type(self) -> scheme_types.SchemeFunctionType:
-        return scheme_types.SchemeFunctionType(len(self.params))
 
 
 @dataclass(frozen=True)

--- a/sexp.py
+++ b/sexp.py
@@ -50,7 +50,7 @@ class SNum(Value):
         return self.value
 
     def scheme_type(self) -> scheme_types.SchemeNumType:
-        return scheme_types.SchemeNum#Type(self.value)
+        return scheme_types.SchemeNum
 
 
 @dataclass(frozen=True)
@@ -68,7 +68,7 @@ class SBool(Value):
         return id(self.value)
 
     def scheme_type(self) -> scheme_types.SchemeBoolType:
-        return scheme_types.SchemeBool#Type(self.value)
+        return scheme_types.SchemeBool
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,7 @@ class SSym(Value):
         return id(self.name)
 
     def scheme_type(self) -> scheme_types.SchemeSymType:
-        return scheme_types.SchemeSym#Type(self.name)
+        return scheme_types.SchemeSym
 
 
 @dataclass(frozen=True)

--- a/sexp.py
+++ b/sexp.py
@@ -50,7 +50,7 @@ class SNum(Value):
         return self.value
 
     def scheme_type(self) -> scheme_types.SchemeNumType:
-        return scheme_types.SchemeNum
+        return scheme_types.SchemeNumType(value)
 
 
 @dataclass(frozen=True)

--- a/test_bytecode.py
+++ b/test_bytecode.py
@@ -179,11 +179,13 @@ class BytecodeTestCase(unittest.TestCase):
                           specialization=(scheme_types.SchemeSym,)).run(env)
         assert env[Var('y')] == SBool(True)
 
-        with self.assertRaises(AssertionError):
-            bytecode.CallInst(
-                Var('y'), Var('f'), [SymLit(SSym('x'))],
-                specialization=(scheme_types.SchemeNum,)).run(env)
-        with self.assertRaises(AssertionError):
-            bytecode.CallInst(
-                Var('y'), Var('f'), [NumLit(SNum(42))],
-                specialization=(scheme_types.SchemeNum,)).run(env)
+        # If specialization not found, fall back to dynamic dispatch
+        bytecode.CallInst(
+            Var('y'), Var('f'), [SymLit(SSym('x'))],
+            specialization=(scheme_types.SchemeNum,)).run(env)
+        self.assertEqual(env[Var('y')], SBool(True))
+
+        bytecode.CallInst(
+            Var('y'), Var('f'), [NumLit(SNum(42))],
+            specialization=(scheme_types.SchemeNum,)).run(env)
+        self.assertEqual(env[Var('y')], SBool(False))

--- a/test_bytecode.py
+++ b/test_bytecode.py
@@ -8,7 +8,7 @@ from bytecode import Binop, BoolLit, NumLit, SymLit, Var
 from sexp import SBool, SNum, SSym, SVect
 
 
-class BytecodeTestCast(unittest.TestCase):
+class BytecodeTestCase(unittest.TestCase):
     def test_example_recursive(self) -> None:
         """
         function list? (v0) entry=bb0

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -873,203 +873,154 @@ bb0:
 
     def test_specialize_in_bounds_vector_access(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair 0)
+                (vector-set! pair 1 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeVectType(2),
-                sexp.SSym('n'): scheme_types.SchemeNumType(1)
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
   v0 = lookup 'inst/load
-  v1 = call v0 (v, n)
-  return v1
+  v1 = call v0 (pair, 0)
+  v2 = lookup 'inst/store
+  v3 = call v2 (pair, 1, 42)
+  return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 
     def test_out_of_bounds_vector_access_checks_not_removed(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair 2)
+                (vector-set! pair 2 42)
+
+                (vector-index pair -1)
+                (vector-set! pair -1 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeVectType(2),
-                sexp.SSym('n'): scheme_types.SchemeNumType(3)
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
-  v0 = lookup 'assert
-  v1 = lookup 'number<
-  v2 = lookup 'vector-length
-  v3 = call v2 (v)
-  v4 = call v1 (n, v3)
-  v5 = call v0 (v4)
-  v6 = lookup 'inst/load
-  v7 = call v6 (v, n)
+  v0 = lookup 'vector-index
+  v1 = call v0 (pair, 2)
+  v2 = lookup 'vector-set!
+  v3 = call v2 (pair, 2, 42)
+  v4 = lookup 'vector-index
+  v5 = call v4 (pair, -1)
+  v6 = lookup 'vector-set!
+  v7 = call v6 (pair, -1, 42)
   return v7
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 
     def test_non_constant_index_checks_not_removed(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair index)
+                (vector-set! pair index 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeVectType(2),
-                sexp.SSym('n'): scheme_types.SchemeNum
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
-  v0 = lookup 'assert
-  v1 = lookup 'number<
-  v2 = call v1 (-1, n)
-  v3 = call v0 (v2)
-  v4 = lookup 'assert
-  v5 = lookup 'number<
-  v6 = lookup 'vector-length
-  v7 = call v6 (v)
-  v8 = call v5 (n, v7)
-  v9 = call v4 (v8)
-  v10 = lookup 'inst/load
-  v11 = call v10 (v, n)
-  return v11
+  v0 = lookup 'vector-index
+  v1 = lookup 'index
+  v2 = call v0 (pair, v1)
+  v3 = lookup 'vector-set!
+  v4 = lookup 'index
+  v5 = call v3 (pair, v4, 42)
+  return v5
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 
     def test_vector_access_unknown_vector_size(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair 0)
+                (vector-set! pair 1 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeVectType(None),
-                sexp.SSym('n'): scheme_types.SchemeNumType(0)
+                sexp.SSym('pair'): scheme_types.SchemeVectType(None),
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
-  v0 = lookup 'assert
-  v1 = lookup 'number<
-  v2 = lookup 'vector-length
-  v3 = call v2 (v)
-  v4 = call v1 (n, v3)
-  v5 = call v0 (v4)
-  v6 = lookup 'inst/load
-  v7 = call v6 (v, n)
-  return v7
+  v0 = lookup 'vector-index
+  v1 = call v0 (pair, 0)
+  v2 = lookup 'vector-set!
+  v3 = call v2 (pair, 1, 42)
+  return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 
     def test_vector_access_non_vector(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair 0)
+                (vector-set! pair 1 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeObject,
-                sexp.SSym('n'): scheme_types.SchemeNumType(0)
+                sexp.SSym('pair'): scheme_types.SchemeObject,
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
-  v0 = lookup 'assert
-  v1 = lookup 'vector?
-  v2 = call v1 (v)
-  v3 = call v0 (v2)
-  v4 = lookup 'assert
-  v5 = lookup 'number<
-  v6 = lookup 'vector-length
-  v7 = call v6 (v)
-  v8 = call v5 (n, v7)
-  v9 = call v4 (v8)
-  v10 = lookup 'inst/load
-  v11 = call v10 (v, n)
-  return v11
+  v0 = lookup 'vector-index
+  v1 = call v0 (pair, 0)
+  v2 = lookup 'vector-set!
+  v3 = call v2 (pair, 1, 42)
+  return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 
     def test_vector_access_non_number_index(self) -> None:
         code = '''
-            (define (my-vector-index v n)
-                (assert (vector? v))
-                (assert (number? n))
-                (assert (number< -1 n))
-                (assert (number< n (vector-length v)))
-                (inst/load v n)
+            (define (pairy pair)
+                (vector-index pair true)
+                (vector-set! pair false 42)
             )'''
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('v'): scheme_types.SchemeVectType(2),
-                sexp.SSym('n'): scheme_types.SchemeBoolType(True)
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
             }
         )
 
         expected = '''
-function (? v n) entry=bb0
+function (? pair) entry=bb0
 bb0:
-  v0 = lookup 'assert
-  v1 = lookup 'number?
-  v2 = call v1 (n)
-  v3 = call v0 (v2)
-  v4 = lookup 'assert
-  v5 = lookup 'number<
-  v6 = call v5 (-1, n)
-  v7 = call v4 (v6)
-  v8 = lookup 'assert
-  v9 = lookup 'number<
-  v10 = lookup 'vector-length
-  v11 = call v10 (v)
-  v12 = call v9 (n, v11)
-  v13 = call v8 (v12)
-  v14 = lookup 'inst/load
-  v15 = call v14 (v, n)
-  return v15
+  v0 = lookup 'vector-index
+  v1 = call v0 (pair, 'True)
+  v2 = lookup 'vector-set!
+  v3 = call v2 (pair, 'False, 42)
+  return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
 

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -678,15 +678,12 @@ class EmitFunctionDefTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(1, len(self.function_emitter.global_env))
-        actual_func = self.function_emitter.global_env[sexp.SSym('func')]
-        assert isinstance(actual_func, sexp.SFunction)
-        self.assertEqual(expected, actual_func.code)
+        self.assertEqual(expected, self.function_emitter.get_emitted_func())
 
     def test_emit_multiple_function_defs(self) -> None:
         prog = sexp.parse('(define (func) 42) (define (func2) 43)')
-        self.function_emitter.visit(prog)
 
+        self.function_emitter.visit(prog[0])
         expected_func = bytecode.Function(
             [],
             bytecode.BasicBlock(
@@ -694,7 +691,10 @@ class EmitFunctionDefTestCase(unittest.TestCase):
                 [bytecode.ReturnInst(bytecode.NumLit(sexp.SNum(42)))]
             )
         )
+        self.assertEqual(
+            expected_func, self.function_emitter.get_emitted_func())
 
+        self.function_emitter.visit(prog[1])
         expected_func2 = bytecode.Function(
             [],
             bytecode.BasicBlock(
@@ -702,16 +702,8 @@ class EmitFunctionDefTestCase(unittest.TestCase):
                 [bytecode.ReturnInst(bytecode.NumLit(sexp.SNum(43)))]
             )
         )
-
-        self.assertEqual(2, len(self.function_emitter.global_env))
-
-        actual_func = self.function_emitter.global_env[sexp.SSym('func')]
-        assert isinstance(actual_func, sexp.SFunction)
-        self.assertEqual(expected_func, actual_func.code)
-
-        actual_func2 = self.function_emitter.global_env[sexp.SSym('func2')]
-        assert isinstance(actual_func2, sexp.SFunction)
-        self.assertEqual(expected_func2, actual_func2.code)
+        self.assertEqual(
+            expected_func2, self.function_emitter.get_emitted_func())
 
     def test_emit_lambda_def(self) -> None:
         prog = sexp.parse('(define (func) (lambda (spam) spam))')
@@ -741,12 +733,10 @@ class EmitFunctionDefTestCase(unittest.TestCase):
             )
         )
 
-        actual_func = self.function_emitter.global_env[sexp.SSym('func')]
-        assert isinstance(actual_func, sexp.SFunction)
-        self.assertEqual(expected_func, actual_func.code)
+        self.assertEqual(expected_func,
+                         self.function_emitter.get_emitted_func())
 
         actual_lambda = (
             self.function_emitter.global_env[sexp.SSym('__lambda0')])
         assert isinstance(actual_lambda, sexp.SFunction)
-        self.assertEqual(expected_lambda,
-        self.function_emitter.get_emitted_func().code)
+        self.assertEqual(expected_lambda, actual_lambda.code)

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -889,9 +889,13 @@ bb0:
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'inst/load
+  v1 = call v0 (v, n)
+  return v1
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     def test_out_of_bounds_vector_access_checks_not_removed(self) -> None:
         code = '''
@@ -905,14 +909,25 @@ bb0:
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+                sexp.SSym('v'): scheme_types.SchemeVectType(2),
+                sexp.SSym('n'): scheme_types.SchemeNumType(3)
             }
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'assert
+  v1 = lookup 'number<
+  v2 = lookup 'vector-length
+  v3 = call v2 (v)
+  v4 = call v1 (n, v3)
+  v5 = call v0 (v4)
+  v6 = lookup 'inst/load
+  v7 = call v6 (v, n)
+  return v7
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     def test_non_constant_index_checks_not_removed(self) -> None:
         code = '''
@@ -926,15 +941,29 @@ bb0:
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+                sexp.SSym('v'): scheme_types.SchemeVectType(2),
                 sexp.SSym('n'): scheme_types.SchemeNum
             }
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'assert
+  v1 = lookup 'number<
+  v2 = call v1 (-1, n)
+  v3 = call v0 (v2)
+  v4 = lookup 'assert
+  v5 = lookup 'number<
+  v6 = lookup 'vector-length
+  v7 = call v6 (v)
+  v8 = call v5 (n, v7)
+  v9 = call v4 (v8)
+  v10 = lookup 'inst/load
+  v11 = call v10 (v, n)
+  return v11
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     def test_vector_access_unknown_vector_size(self) -> None:
         code = '''
@@ -948,14 +977,25 @@ bb0:
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('pair'): scheme_types.SchemeVectType(None),
+                sexp.SSym('v'): scheme_types.SchemeVectType(None),
+                sexp.SSym('n'): scheme_types.SchemeNumType(0)
             }
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'assert
+  v1 = lookup 'number<
+  v2 = lookup 'vector-length
+  v3 = call v2 (v)
+  v4 = call v1 (n, v3)
+  v5 = call v0 (v4)
+  v6 = lookup 'inst/load
+  v7 = call v6 (v, n)
+  return v7
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     def test_vector_access_non_vector(self) -> None:
         code = '''
@@ -969,14 +1009,29 @@ bb0:
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('pair'): scheme_types.SchemeObject,
+                sexp.SSym('v'): scheme_types.SchemeObject,
+                sexp.SSym('n'): scheme_types.SchemeNumType(0)
             }
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'assert
+  v1 = lookup 'vector?
+  v2 = call v1 (v)
+  v3 = call v0 (v2)
+  v4 = lookup 'assert
+  v5 = lookup 'number<
+  v6 = lookup 'vector-length
+  v7 = call v6 (v)
+  v8 = call v5 (n, v7)
+  v9 = call v4 (v8)
+  v10 = lookup 'inst/load
+  v11 = call v10 (v, n)
+  return v11
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     def test_vector_access_non_number_index(self) -> None:
         code = '''
@@ -990,14 +1045,33 @@ bb0:
         optimized = self.get_optimized_func_bytecode(
             code,
             param_types={
-                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+                sexp.SSym('v'): scheme_types.SchemeVectType(2),
+                sexp.SSym('n'): scheme_types.SchemeBoolType(True)
             }
         )
 
         expected = '''
+function (? v n) entry=bb0
+bb0:
+  v0 = lookup 'assert
+  v1 = lookup 'number?
+  v2 = call v1 (n)
+  v3 = call v0 (v2)
+  v4 = lookup 'assert
+  v5 = lookup 'number<
+  v6 = call v5 (-1, n)
+  v7 = call v4 (v6)
+  v8 = lookup 'assert
+  v9 = lookup 'number<
+  v10 = lookup 'vector-length
+  v11 = call v10 (v)
+  v12 = call v9 (n, v11)
+  v13 = call v8 (v12)
+  v14 = lookup 'inst/load
+  v15 = call v14 (v, n)
+  return v15
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-        self.fail()
 
     # -------------------------------------------------------------------------
 

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -872,6 +872,131 @@ bb0:
     # -------------------------------------------------------------------------
 
     def test_specialize_in_bounds_vector_access(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('v'): scheme_types.SchemeVectType(2),
+                sexp.SSym('n'): scheme_types.SchemeNumType(1)
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
+        self.fail()
+
+    def test_out_of_bounds_vector_access_checks_not_removed(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
+        self.fail()
+
+    def test_non_constant_index_checks_not_removed(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+                sexp.SSym('n'): scheme_types.SchemeNum
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
+        self.fail()
+
+    def test_vector_access_unknown_vector_size(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('pair'): scheme_types.SchemeVectType(None),
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
+        self.fail()
+
+    def test_vector_access_non_vector(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('pair'): scheme_types.SchemeObject,
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
+        self.fail()
+
+    def test_vector_access_non_number_index(self) -> None:
+        code = '''
+            (define (my-vector-index v n)
+                (assert (vector? v))
+                (assert (number? n))
+                (assert (number< -1 n))
+                (assert (number< n (vector-length v)))
+                (inst/load v n)
+            )'''
+        optimized = self.get_optimized_func_bytecode(
+            code,
+            param_types={
+                sexp.SSym('pair'): scheme_types.SchemeVectType(2),
+            }
+        )
+
+        expected = '''
+        '''
+        self.assertEqual(expected.strip(), optimized.strip())
         self.fail()
 
     # -------------------------------------------------------------------------

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -804,10 +804,10 @@ function (? first second) entry=bb0
 bb0:
   v0 = lookup 'assert
   v1 = lookup 'number?
-  v2 = call v1 (second)
-  v3 = call v0 (v2)
+  v2 = call v1 (second) (SchemeObjectType())
+  v3 = call v0 (v2) (SchemeBoolType())
   v4 = lookup 'inst/+
-  v5 = call v4 (first, second)
+  v5 = call v4 (first, second) (SchemeNumType(), SchemeObjectType())
   return v5
 '''
 
@@ -834,7 +834,7 @@ bb0:
 function (? first second) entry=bb0
 bb0:
   v0 = lookup 'inst/+
-  v1 = call v0 (first, second)
+  v1 = call v0 (first, second) (SchemeNumType(), SchemeNumType())
   return v1
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -861,10 +861,10 @@ function (? first second) entry=bb0
 bb0:
   v0 = lookup 'inst/+
   v1 = lookup '+
-  v2 = call v1 (1, first)
+  v2 = call v1 (1, first) (SchemeNumType(), SchemeNumType())
   v3 = lookup '+
-  v4 = call v3 (second, 1)
-  v5 = call v0 (v2, v4)
+  v4 = call v3 (second, 1) (SchemeNumType(), SchemeNumType())
+  v5 = call v0 (v2, v4) (SchemeNumType(), SchemeNumType())
   return v5
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -888,9 +888,10 @@ bb0:
 function (? pair) entry=bb0
 bb0:
   v0 = lookup 'inst/load
-  v1 = call v0 (pair, 0)
+  v1 = call v0 (pair, 0) (SchemeVectType(length=2), SchemeNumType())
   v2 = lookup 'inst/store
-  v3 = call v2 (pair, 1, 42)
+  v3 = call v2 (pair, 1, 42) \
+(SchemeVectType(length=2), SchemeNumType(), SchemeNumType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -915,13 +916,15 @@ bb0:
 function (? pair) entry=bb0
 bb0:
   v0 = lookup 'vector-index
-  v1 = call v0 (pair, 2)
+  v1 = call v0 (pair, 2) (SchemeVectType(length=2), SchemeNumType())
   v2 = lookup 'vector-set!
-  v3 = call v2 (pair, 2, 42)
+  v3 = call v2 (pair, 2, 42) \
+(SchemeVectType(length=2), SchemeNumType(), SchemeNumType())
   v4 = lookup 'vector-index
-  v5 = call v4 (pair, -1)
+  v5 = call v4 (pair, -1) (SchemeVectType(length=2), SchemeNumType())
   v6 = lookup 'vector-set!
-  v7 = call v6 (pair, -1, 42)
+  v7 = call v6 (pair, -1, 42) \
+(SchemeVectType(length=2), SchemeNumType(), SchemeNumType())
   return v7
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -944,10 +947,11 @@ function (? pair) entry=bb0
 bb0:
   v0 = lookup 'vector-index
   v1 = lookup 'index
-  v2 = call v0 (pair, v1)
+  v2 = call v0 (pair, v1) (SchemeVectType(length=2), SchemeObjectType())
   v3 = lookup 'vector-set!
   v4 = lookup 'index
-  v5 = call v3 (pair, v4, 42)
+  v5 = call v3 (pair, v4, 42) \
+(SchemeVectType(length=2), SchemeObjectType(), SchemeNumType())
   return v5
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -969,9 +973,10 @@ bb0:
 function (? pair) entry=bb0
 bb0:
   v0 = lookup 'vector-index
-  v1 = call v0 (pair, 0)
+  v1 = call v0 (pair, 0) (SchemeVectType(length=None), SchemeNumType())
   v2 = lookup 'vector-set!
-  v3 = call v2 (pair, 1, 42)
+  v3 = call v2 (pair, 1, 42) \
+(SchemeVectType(length=None), SchemeNumType(), SchemeNumType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -993,9 +998,10 @@ bb0:
 function (? pair) entry=bb0
 bb0:
   v0 = lookup 'vector-index
-  v1 = call v0 (pair, 0)
+  v1 = call v0 (pair, 0) (SchemeObjectType(), SchemeNumType())
   v2 = lookup 'vector-set!
-  v3 = call v2 (pair, 1, 42)
+  v3 = call v2 (pair, 1, 42) \
+(SchemeObjectType(), SchemeNumType(), SchemeNumType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1017,17 +1023,13 @@ bb0:
 function (? pair) entry=bb0
 bb0:
   v0 = lookup 'vector-index
-  v1 = call v0 (pair, 'True)
+  v1 = call v0 (pair, 'True) (SchemeVectType(length=2), SchemeBoolType())
   v2 = lookup 'vector-set!
-  v3 = call v2 (pair, 'False, 42)
+  v3 = call v2 (pair, 'False, 42) \
+(SchemeVectType(length=2), SchemeBoolType(), SchemeNumType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
-
-    # -------------------------------------------------------------------------
-
-    def test_call_inst_in_specialized_func_includes_types(self) -> None:
-        self.fail()
 
     # -------------------------------------------------------------------------
 
@@ -1046,7 +1048,7 @@ bb0:
         expected = '''
 function (? func) entry=bb0
 bb0:
-  v0 = call func (42)
+  v0 = call func (42) (SchemeNumType())
   return v0
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1071,7 +1073,7 @@ bb0:
   v0 = arity func
   v1 = Binop.NUM_EQ v0 2
   brn v1 wrong_arity
-  v2 = call func (42, 43)
+  v2 = call func (42, 43) (SchemeNumType(), SchemeNumType())
   return v2
 
 wrong_arity:
@@ -1099,7 +1101,7 @@ bb0:
   v0 = arity func
   v1 = Binop.NUM_EQ v0 1
   brn v1 wrong_arity
-  v2 = call func (42)
+  v2 = call func (42) (SchemeNumType())
   return v2
 
 wrong_arity:
@@ -1120,7 +1122,7 @@ wrong_arity:
 function (? ) entry=bb0
 bb0:
   v0 = lookup '__lambda0
-  v1 = call v0 (42)
+  v1 = call v0 (42) (SchemeNumType())
   return v1
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1141,7 +1143,7 @@ bb0:
   v1 = arity v0
   v2 = Binop.NUM_EQ v1 2
   brn v2 wrong_arity
-  v3 = call v0 (42, 43)
+  v3 = call v0 (42, 43) (SchemeNumType(), SchemeNumType())
   return v3
 
 wrong_arity:
@@ -1177,7 +1179,7 @@ bb0:
   v1 = arity v0
   v2 = Binop.NUM_EQ v1 1
   brn v2 wrong_arity
-  v3 = call v0 (42)
+  v3 = call v0 (42) (SchemeNumType())
   return v3
 
 wrong_arity:
@@ -1195,7 +1197,7 @@ wrong_arity:
 function (? ) entry=bb0
 bb0:
   v0 = lookup '+
-  v1 = call v0 (3, 4)
+  v1 = call v0 (3, 4) (SchemeNumType(), SchemeNumType())
   return v1
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1213,7 +1215,7 @@ bb0:
   v1 = arity v0
   v2 = Binop.NUM_EQ v1 2
   brn v2 wrong_arity
-  v3 = call v0 (3, 4)
+  v3 = call v0 (3, 4) (SchemeNumType(), SchemeNumType())
   return v3
 
 wrong_arity:
@@ -1235,7 +1237,7 @@ bb0:
   v1 = arity v0
   v2 = Binop.NUM_EQ v1 1
   brn v2 wrong_arity
-  v3 = call v0 (42)
+  v3 = call v0 (42) (SchemeNumType())
   return v3
 
 wrong_arity:
@@ -1278,7 +1280,7 @@ bb0:
 function (? egg) entry=bb0
 bb0:
   v0 = lookup '+
-  v1 = call v0 (egg, 1)
+  v1 = call v0 (egg, 1) (SchemeNumType(), SchemeNumType())
   egg = v1
   jmp bb0
   return 0
@@ -1302,7 +1304,7 @@ bb0:
 function (? egg) entry=bb0
 bb0:
   v0 = lookup 'spam
-  v1 = call v0 ('True)
+  v1 = call v0 ('True) (SchemeBoolType())
   return v1
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1355,8 +1357,8 @@ function (? func) entry=bb0
 bb0:
   v0 = lookup 'assert
   v1 = lookup 'function?
-  v2 = call v1 (func)
-  v3 = call v0 (v2)
+  v2 = call v1 (func) (SchemeObjectType())
+  v3 = call v0 (v2) (SchemeBoolType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())
@@ -1441,8 +1443,8 @@ function (? egg) entry=bb0
 bb0:
   v0 = lookup 'assert
   v1 = lookup 'vector?
-  v2 = call v1 (egg)
-  v3 = call v0 (v2)
+  v2 = call v1 (egg) (SchemeObjectType())
+  v3 = call v0 (v2) (SchemeBoolType())
   return v3
         '''
         self.assertEqual(expected.strip(), optimized.strip())

--- a/test_emit_IR.py
+++ b/test_emit_IR.py
@@ -748,4 +748,5 @@ class EmitFunctionDefTestCase(unittest.TestCase):
         actual_lambda = (
             self.function_emitter.global_env[sexp.SSym('__lambda0')])
         assert isinstance(actual_lambda, sexp.SFunction)
-        self.assertEqual(expected_lambda, actual_lambda.code)
+        self.assertEqual(expected_lambda,
+        self.function_emitter.get_emitted_func().code)

--- a/test_find_tail_calls.py
+++ b/test_find_tail_calls.py
@@ -1,6 +1,8 @@
 import unittest
 from typing import List
 
+import emit_IR
+import scheme_types
 import sexp
 from find_tail_calls import TailCallData, TailCallFinder
 

--- a/test_scheme_types.py
+++ b/test_scheme_types.py
@@ -14,7 +14,7 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         analyzer.visit(prog)
 
         types = list(analyzer.get_expr_types().values())
-        self.assertEqual([scheme_types.SchemeSymType('spam')], types)
+        self.assertEqual([scheme_types.SchemeSym], types)
 
     def test_quoted_list(self) -> None:
         prog = sexp.parse("'(1 2 3)")
@@ -30,7 +30,7 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         analyzer.visit(prog)
 
         types = list(analyzer.get_expr_types().values())
-        self.assertEqual([scheme_types.SchemeNumType(42)], types)
+        self.assertEqual([scheme_types.SchemeNum], types)
 
     def test_bool_literal(self) -> None:
         prog = sexp.parse("true false booly")
@@ -41,8 +41,8 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
 
         types = list(analyzer.get_expr_types().values())
         expected = [
-            scheme_types.SchemeBoolType(True),
-            scheme_types.SchemeBoolType(False),
+            scheme_types.SchemeBool,
+            scheme_types.SchemeBool,
             scheme_types.SchemeBool
         ]
         self.assertEqual(expected, types)
@@ -125,7 +125,7 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         expected = [
             scheme_types.SchemeFunctionType(1, scheme_types.SchemeBool),
-            scheme_types.SchemeNumType(42),
+            scheme_types.SchemeNum,
             scheme_types.SchemeBool
         ]
         self.assertEqual(expected, types)
@@ -145,7 +145,7 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
 
             # Args to +
             scheme_types.SchemeNum,
-            scheme_types.SchemeNumType(1),
+            scheme_types.SchemeNum,
 
             # + return val
             scheme_types.SchemeNum,
@@ -163,37 +163,9 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         expected = [
             scheme_types.SchemeObject,
-            scheme_types.SchemeBoolType(True),
-            scheme_types.SchemeBoolType(False),
             scheme_types.SchemeBool,
-        ]
-        self.assertEqual(expected, types)
-
-    def test_conditional_test_true_type_is_then_branch(self) -> None:
-        prog = sexp.parse("(if true true false)")
-        analyzer = FunctionTypeAnalyzer({}, {})
-        analyzer.visit(prog)
-
-        types = list(analyzer.get_expr_types().values())
-        expected = [
-            scheme_types.SchemeBoolType(True),
-            scheme_types.SchemeBoolType(True),
-            scheme_types.SchemeBoolType(False),
-            scheme_types.SchemeBoolType(True),
-        ]
-        self.assertEqual(expected, types)
-
-    def test_conditional_test_false_type_is_else_branch(self) -> None:
-        prog = sexp.parse("(if false true false)")
-        analyzer = FunctionTypeAnalyzer({}, {})
-        analyzer.visit(prog)
-
-        types = list(analyzer.get_expr_types().values())
-        expected = [
-            scheme_types.SchemeBoolType(False),
-            scheme_types.SchemeBoolType(True),
-            scheme_types.SchemeBoolType(False),
-            scheme_types.SchemeBoolType(False),
+            scheme_types.SchemeBool,
+            scheme_types.SchemeBool,
         ]
         self.assertEqual(expected, types)
 
@@ -205,8 +177,8 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         expected = [
             scheme_types.SchemeObject,
-            scheme_types.SchemeNumType(42),
-            scheme_types.SchemeBoolType(False),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeBool,
             scheme_types.SchemeObject,
         ]
         self.assertEqual(expected, types)
@@ -219,9 +191,9 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         expected = [
             scheme_types.SchemeObject,
-            scheme_types.SchemeNumType(42),
-            scheme_types.SchemeNumType(42),
-            scheme_types.SchemeNumType(42),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
         ]
         self.assertEqual(expected, types)
 
@@ -233,8 +205,8 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         expected = [
             scheme_types.SchemeObject,
-            scheme_types.SchemeNumType(42),
-            scheme_types.SchemeNumType(43),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
             scheme_types.SchemeNum,
         ]
         self.assertEqual(expected, types)
@@ -324,37 +296,9 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         expected = [
             scheme_types.SchemeFunctionType(
                 2, scheme_types.SchemeVectType(None)),
-            scheme_types.SchemeNumType(3),
-            scheme_types.SchemeBoolType(True),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeBool,
             scheme_types.SchemeVectType(3),
-        ]
-        self.assertEqual(expected, types)
-
-    def test_vector_make_known_size_param(self) -> None:
-        prog = sexp.parse("(define (spam size) (vector-make size true))")
-        analyzer = FunctionTypeAnalyzer(
-            {sexp.SSym('size'): scheme_types.SchemeNumType(4)}, {})
-        analyzer.visit(prog)
-
-        types = list(analyzer.get_expr_types().values())
-        expected = [
-            # size param
-            scheme_types.SchemeNumType(4),
-
-            # vector-make
-            scheme_types.SchemeFunctionType(
-                2, scheme_types.SchemeVectType(None)),
-
-            # size use
-            scheme_types.SchemeNumType(4),
-            scheme_types.SchemeBoolType(True),
-
-            # return type
-            scheme_types.SchemeVectType(4),
-
-            # function type
-            scheme_types.SchemeFunctionType(
-                1, scheme_types.SchemeVectType(4)),
         ]
         self.assertEqual(expected, types)
 
@@ -375,7 +319,7 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
 
             # size use
             scheme_types.SchemeNum,
-            scheme_types.SchemeBoolType(True),
+            scheme_types.SchemeBool,
 
             # return type
             scheme_types.SchemeVectType(None),

--- a/test_scheme_types.py
+++ b/test_scheme_types.py
@@ -1,45 +1,156 @@
 import unittest
 
+import scheme_types
+import sexp
+from scheme_types import FunctionTypeAnalyzer
+
 
 class FunctionTypeAnalyzerTestCase(unittest.TestCase):
     def test_quoted_symbol(self) -> None:
-        self.fail()
+        prog = sexp.parse("'spam")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeQuotedType(sexp.SSym)], types)
 
     def test_quoted_list(self) -> None:
-        self.fail()
+        prog = sexp.parse("'(1 2 3)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeVectType(2)], types)
 
     def test_num_literal(self) -> None:
-        self.fail()
+        prog = sexp.parse("42")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeNum], types)
 
     def test_bool_literal(self) -> None:
-        self.fail()
+        prog = sexp.parse("true")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeBool], types)
 
     def test_sym_literal_not_function(self) -> None:
-        self.fail()
+        prog = sexp.parse("spam")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeObject], types)
 
     def test_sym_literal_is_local_function(self) -> None:
-        self.fail()
+        param_types = {sexp.SSym('spam'): scheme_types.SchemeFunctionType(1)}
+
+        prog = sexp.parse("spam")
+        analyzer = FunctionTypeAnalyzer(param_types)
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeFunctionType(1)], types)
 
     def test_sym_literal_is_builtin_function(self) -> None:
-        self.fail()
+        prog = sexp.parse("number=")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual(
+            [scheme_types.SchemeFunctionType(2, scheme_types.SchemeBool)],
+            types)
 
     def test_function_def(self) -> None:
-        self.fail()
+        prog = sexp.parse("(define (spam egg) egg)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+
+        func_type = scheme_types.SchemeFunctionType(
+            1, scheme_types.SchemeObject)
+        expected = [
+            scheme_types.SchemeObject,
+            func_type,
+        ]
+        self.assertEqual(expected, types)
+        self.assertEqual(func_type, analyzer.get_function_type())
 
     def test_function_call_type_unknown(self) -> None:
-        self.fail()
+        prog = sexp.parse("(spam)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual(
+            [scheme_types.SchemeObject, scheme_types.SchemeObject], types)
 
     def test_builtin_function_call_type(self) -> None:
-        self.fail()
+        prog = sexp.parse("(number? 42)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        expected = [
+            scheme_types.SchemeFunctionType(1, scheme_types.SchemeBool),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeBool
+        ]
+        self.assertEqual(expected, types)
+
+    def test_user_function_return_type_deduced(self) -> None:
+        prog = sexp.parse("(define (spam egg) (+ egg 1))")
+        analyzer = FunctionTypeAnalyzer(
+            {sexp.SSym('egg'): scheme_types.SchemeNum})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        expected = [
+            # + signature
+            scheme_types.SchemeFunctionType(2, scheme_types.SchemeNum),
+
+            # Args to +
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
+
+            # + return val
+            scheme_types.SchemeNum,
+
+            # spam signature
+            scheme_types.SchemeFunctionType(1, scheme_types.SchemeNum),
+        ]
+        self.assertEqual(expected, types)
 
     def test_conditional_same_type_branches(self) -> None:
-        self.fail()
+        prog = sexp.parse("(if true 42 43)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        expected = [
+            scheme_types.SchemeBool,
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
+            scheme_types.SchemeNum,
+        ]
+        self.assertEqual(expected, types)
 
     def test_conditional_different_type_branches(self) -> None:
-        self.fail()
+        prog = sexp.parse("(if true 42 false)")
+        analyzer = FunctionTypeAnalyzer({})
+        analyzer.visit(prog)
 
-    def test_symbol_type_narrowed_by_conditional(self) -> None:
-        self.fail()
-
-    def test_symbol_type_narrowed_by_assert(self) -> None:
-        self.fail()
+        types = list(analyzer.get_expr_types().values())
+        expected = [
+            scheme_types.SchemeBool,
+            scheme_types.SchemeNum,
+            scheme_types.SchemeBool,
+            scheme_types.SchemeObject,
+        ]
+        self.assertEqual(expected, types)

--- a/test_scheme_types.py
+++ b/test_scheme_types.py
@@ -1,0 +1,45 @@
+import unittest
+
+
+class FunctionTypeAnalyzerTestCase(unittest.TestCase):
+    def test_quoted_symbol(self) -> None:
+        self.fail()
+
+    def test_quoted_list(self) -> None:
+        self.fail()
+
+    def test_num_literal(self) -> None:
+        self.fail()
+
+    def test_bool_literal(self) -> None:
+        self.fail()
+
+    def test_sym_literal_not_function(self) -> None:
+        self.fail()
+
+    def test_sym_literal_is_local_function(self) -> None:
+        self.fail()
+
+    def test_sym_literal_is_builtin_function(self) -> None:
+        self.fail()
+
+    def test_function_def(self) -> None:
+        self.fail()
+
+    def test_function_call_type_unknown(self) -> None:
+        self.fail()
+
+    def test_builtin_function_call_type(self) -> None:
+        self.fail()
+
+    def test_conditional_same_type_branches(self) -> None:
+        self.fail()
+
+    def test_conditional_different_type_branches(self) -> None:
+        self.fail()
+
+    def test_symbol_type_narrowed_by_conditional(self) -> None:
+        self.fail()
+
+    def test_symbol_type_narrowed_by_assert(self) -> None:
+        self.fail()

--- a/test_scheme_types.py
+++ b/test_scheme_types.py
@@ -92,7 +92,8 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         func_type = scheme_types.SchemeFunctionType(
             1, scheme_types.SchemeObject)
         expected = [
-            scheme_types.SchemeObject,
+            scheme_types.SchemeObject,  # egg param symbol
+            scheme_types.SchemeObject,  # egg usage symbol
             func_type,
         ]
         self.assertEqual(expected, types)
@@ -128,6 +129,8 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
 
         types = list(analyzer.get_expr_types().values())
         expected = [
+            scheme_types.SchemeNum,  # egg param
+
             # + signature
             scheme_types.SchemeFunctionType(2, scheme_types.SchemeNum),
 

--- a/test_scheme_types.py
+++ b/test_scheme_types.py
@@ -24,6 +24,22 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
         types = list(analyzer.get_expr_types().values())
         self.assertEqual([scheme_types.SchemeVectType(2)], types)
 
+    def test_vector_literal(self) -> None:
+        prog = sexp.parse("[1 2 3 4]")
+        analyzer = FunctionTypeAnalyzer({}, {})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeVectType(4)], types)
+
+    def test_vector_literal_size_above_specialization_threshold(self) -> None:
+        prog = sexp.parse("[1 2 3 4 5]")
+        analyzer = FunctionTypeAnalyzer({}, {})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        self.assertEqual([scheme_types.SchemeVectType(None)], types)
+
     def test_num_literal(self) -> None:
         prog = sexp.parse("42")
         analyzer = FunctionTypeAnalyzer({}, {})
@@ -327,5 +343,20 @@ class FunctionTypeAnalyzerTestCase(unittest.TestCase):
             # function type
             scheme_types.SchemeFunctionType(
                 1, scheme_types.SchemeVectType(None)),
+        ]
+        self.assertEqual(expected, types)
+
+    def test_vector_make_size_above_specialization_threshold(self) -> None:
+        prog = sexp.parse("(vector-make 5 true)")
+        analyzer = FunctionTypeAnalyzer({}, {})
+        analyzer.visit(prog)
+
+        types = list(analyzer.get_expr_types().values())
+        expected = [
+            scheme_types.SchemeFunctionType(
+                2, scheme_types.SchemeVectType(None)),
+            scheme_types.SchemeNum,
+            scheme_types.SchemeBool,
+            scheme_types.SchemeVectType(None),
         ]
         self.assertEqual(expected, types)


### PR DESCRIPTION
Also adds two flags to the interpreter for selecting naive or bytecode specialization.

Naive specialization includes:
- Removing true type assertions (using `assert`)
- Removing true bounds checks for vectors up to and including size 4. (This is accomplished by replacing vector-index and vector-set! with inst/load and inst/store)

Still to do for naive approach:
- Convert arithmetic and comparison operators to their instruction forms.